### PR TITLE
Add option to set default quote style via checkbox

### DIFF
--- a/app/src/main/java/com/shalenmathew/quotesapp/data/local/DefaultQuoteStylePreferencesImpl.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/local/DefaultQuoteStylePreferencesImpl.kt
@@ -1,0 +1,39 @@
+package com.shalenmathew.quotesapp.data.local
+
+import android.content.SharedPreferences
+import com.shalenmathew.quotesapp.domain.repository.DefaultQuoteStylePreferences
+import com.shalenmathew.quotesapp.presentation.screens.share_screen.QuoteStyle
+import androidx.core.content.edit
+import jakarta.inject.Inject
+
+class DefaultQuoteStylePreferencesImpl @Inject constructor(
+    private val sharedPreferences: SharedPreferences
+): DefaultQuoteStylePreferences {
+
+    override fun saveDefaultQuoteStyle(quoteStyle: QuoteStyle) {
+        val quoteStyleString = when (quoteStyle) {
+            is QuoteStyle.DefaultTheme -> "DefaultTheme"
+            is QuoteStyle.CodeSnippetTheme -> "CodeSnippetTheme"
+            is QuoteStyle.SpotifyTheme -> "SpotifyTheme"
+            is QuoteStyle.bratTheme -> "bratTheme"
+            is QuoteStyle.igorTheme -> "igorTheme"
+        }
+        sharedPreferences.edit {
+            putString(QUOTE_STYLE_KEY, quoteStyleString)
+        }
+    }
+
+    override fun getDefaultQuoteStyle(): QuoteStyle {
+        return when (sharedPreferences.getString(QUOTE_STYLE_KEY, "DefaultTheme")) {
+            "CodeSnippetTheme" -> QuoteStyle.CodeSnippetTheme
+            "SpotifyTheme" -> QuoteStyle.SpotifyTheme
+            "bratTheme" -> QuoteStyle.bratTheme
+            "igorTheme" -> QuoteStyle.igorTheme
+            else -> QuoteStyle.DefaultTheme
+        }
+    }
+
+    companion object {
+        private const val QUOTE_STYLE_KEY = "quote_style_key"
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/di/AppModule.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/di/AppModule.kt
@@ -1,11 +1,15 @@
 package com.shalenmathew.quotesapp.di
 
 import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.room.Room
+import com.shalenmathew.quotesapp.data.local.DefaultQuoteStylePreferencesImpl
 import com.shalenmathew.quotesapp.data.local.QuoteDatabase
 import com.shalenmathew.quotesapp.data.remote.QuoteApi
 import com.shalenmathew.quotesapp.data.repository.FavQuoteRepositoryImpl
 import com.shalenmathew.quotesapp.data.repository.QuoteRepositoryImplementation
+import com.shalenmathew.quotesapp.domain.repository.DefaultQuoteStylePreferences
 import com.shalenmathew.quotesapp.domain.repository.FavQuoteRepository
 import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.FavLikedQuote
@@ -18,6 +22,7 @@ import com.shalenmathew.quotesapp.util.Constants
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -71,4 +76,20 @@ fun providesQuoteRepository(api:QuoteApi,db:QuoteDatabase):QuoteRepository{
             .create(QuoteApi::class.java)
     }
 
+    @Provides
+    @Singleton
+    fun providesSharedPreferences(
+        @ApplicationContext context: Context
+    ): SharedPreferences {
+        return context.getSharedPreferences(
+            Constants.SHARED_PREFERENCES_NAME,
+            Context.MODE_PRIVATE
+        )
+    }
+
+    @Singleton
+    @Provides
+    fun providesDefaultQuoteStylePreferences(sharedPreferences: SharedPreferences): DefaultQuoteStylePreferences {
+        return DefaultQuoteStylePreferencesImpl(sharedPreferences)
+    }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/DefaultQuoteStylePreferences.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/DefaultQuoteStylePreferences.kt
@@ -1,0 +1,8 @@
+package com.shalenmathew.quotesapp.domain.repository
+
+import com.shalenmathew.quotesapp.presentation.screens.share_screen.QuoteStyle
+
+interface DefaultQuoteStylePreferences {
+    fun saveDefaultQuoteStyle(quoteStyle: QuoteStyle)
+    fun getDefaultQuoteStyle(): QuoteStyle
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/ShareScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/ShareScreen.kt
@@ -19,11 +19,13 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,16 +42,22 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.shalenmathew.quotesapp.R
 import com.shalenmathew.quotesapp.domain.model.Quote
 import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.CaptureBitmap
 import com.shalenmathew.quotesapp.presentation.theme.GIFont
+import com.shalenmathew.quotesapp.presentation.viewmodel.ShareQuoteViewModel
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
+fun ShareScreen(
+    paddingValues: PaddingValues,
+    navHost: NavHostController,
+    viewModel: ShareQuoteViewModel= hiltViewModel()
+) {
 
     var imgBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
     val context = LocalContext.current
@@ -58,7 +66,9 @@ fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
     val scrollState = rememberScrollState()
     var quoteStyleState by remember { mutableStateOf<QuoteStyle>(QuoteStyle.DefaultTheme) }
 
-
+    LaunchedEffect(Unit) {
+        quoteStyleState = viewModel.getDefaultQuoteStyle()
+    }
     val quote = navHost.previousBackStackEntry?.savedStateHandle?.get<Quote>("quote")
 
     Box(
@@ -184,16 +194,28 @@ fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
 
                     Row(modifier = Modifier.fillMaxWidth()
                         .wrapContentHeight()) {
-
-                        Image(painter = painterResource(R.drawable.sample_code_snippet),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(200.dp)
-                                .clickable{
-                                    quoteStyleState = QuoteStyle.CodeSnippetTheme
-                                    showSheet=false
-                                },
-                            contentScale = ContentScale.Fit)
+                        Box{
+                            Image(painter = painterResource(R.drawable.sample_code_snippet),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(200.dp)
+                                    .clickable{
+                                        quoteStyleState = QuoteStyle.CodeSnippetTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        showSheet=false
+                                    },
+                                contentScale = ContentScale.Fit)
+                            Checkbox(
+                                modifier = Modifier.align(Alignment.BottomEnd),
+                                checked = quoteStyleState == QuoteStyle.CodeSnippetTheme,
+                                onCheckedChange = { isChecked ->
+                                    if (isChecked) {
+                                        quoteStyleState = QuoteStyle.CodeSnippetTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                    }
+                                }
+                            )
+                        }
                     }
 
                 }
@@ -211,14 +233,29 @@ fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
                     )
 
                     Row(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
-                        Image(painter = painterResource(R.drawable.sample_brat_theme),
-                            contentDescription = null,
-                            modifier = Modifier.size(200.dp)
-                                .clickable{
-                                    quoteStyleState = QuoteStyle.bratTheme
-                                    showSheet=false
-                                },
-                            contentScale = ContentScale.Fit)
+                        Box {
+                            Image(
+                                painter = painterResource(R.drawable.sample_brat_theme),
+                                contentDescription = null,
+                                modifier = Modifier.size(200.dp)
+                                    .clickable {
+                                        quoteStyleState = QuoteStyle.bratTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        showSheet = false
+                                    },
+                                contentScale = ContentScale.Fit
+                            )
+                            Checkbox(
+                                modifier = Modifier.align(Alignment.BottomEnd),
+                                checked = quoteStyleState == QuoteStyle.bratTheme,
+                                onCheckedChange = { isChecked ->
+                                    if (isChecked) {
+                                        quoteStyleState = QuoteStyle.bratTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                    }
+                                }
+                            )
+                        }
                     }
 
                 }
@@ -236,14 +273,29 @@ fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
                     )
 
                     Row(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
-                        Image(painter = painterResource(R.drawable.sample_igor),
-                            contentDescription = null,
-                            modifier = Modifier.size(200.dp)
-                                .clickable{
-                                    quoteStyleState = QuoteStyle.igorTheme
-                                    showSheet=false
-                                },
-                            contentScale = ContentScale.Fit)
+                        Box {
+                            Image(
+                                painter = painterResource(R.drawable.sample_igor),
+                                contentDescription = null,
+                                modifier = Modifier.size(200.dp)
+                                    .clickable {
+                                        quoteStyleState = QuoteStyle.igorTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        showSheet = false
+                                    },
+                                contentScale = ContentScale.Fit
+                            )
+                            Checkbox(
+                                modifier = Modifier.align(Alignment.BottomEnd),
+                                checked = quoteStyleState == QuoteStyle.igorTheme,
+                                onCheckedChange = { isChecked ->
+                                    if (isChecked) {
+                                        quoteStyleState = QuoteStyle.igorTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                    }
+                                }
+                            )
+                        }
                     }
 
                 }
@@ -262,14 +314,29 @@ fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
                     )
 
                     Row(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
-                        Image(painter = painterResource(R.drawable.sample_spotify_theme),
-                            contentDescription = null,
-                            modifier = Modifier.size(200.dp)
-                                .clickable{
-                                    quoteStyleState = QuoteStyle.SpotifyTheme
-                                    showSheet=false
-                                },
-                            contentScale = ContentScale.Fit)
+                        Box {
+                            Image(
+                                painter = painterResource(R.drawable.sample_spotify_theme),
+                                contentDescription = null,
+                                modifier = Modifier.size(200.dp)
+                                    .clickable {
+                                        quoteStyleState = QuoteStyle.SpotifyTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        showSheet = false
+                                    },
+                                contentScale = ContentScale.Fit
+                            )
+                            Checkbox(
+                                modifier = Modifier.align(Alignment.BottomEnd),
+                                checked = quoteStyleState == QuoteStyle.SpotifyTheme,
+                                onCheckedChange = { isChecked ->
+                                    if (isChecked) {
+                                        quoteStyleState = QuoteStyle.SpotifyTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                    }
+                                }
+                            )
+                        }
                     }
 
                 }
@@ -287,14 +354,29 @@ fun ShareScreen(paddingValues: PaddingValues, navHost: NavHostController) {
                     )
 
                     Row(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
-                        Image(painter = painterResource(R.drawable.sample_default_style),
-                            contentDescription = null,
-                            modifier = Modifier.size(200.dp)
-                                .clickable{
-                                    quoteStyleState = QuoteStyle.DefaultTheme
-                                    showSheet=false
-                                },
-                            contentScale = ContentScale.Fit)
+                        Box {
+                            Image(
+                                painter = painterResource(R.drawable.sample_default_style),
+                                contentDescription = null,
+                                modifier = Modifier.size(200.dp)
+                                    .clickable {
+                                        quoteStyleState = QuoteStyle.DefaultTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        showSheet = false
+                                    },
+                                contentScale = ContentScale.Fit
+                            )
+                            Checkbox(
+                                modifier = Modifier.align(Alignment.BottomEnd),
+                                checked = quoteStyleState == QuoteStyle.DefaultTheme,
+                                onCheckedChange = { isChecked ->
+                                    if (isChecked) {
+                                        quoteStyleState = QuoteStyle.DefaultTheme
+                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                    }
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/ShareQuoteViewModel.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/ShareQuoteViewModel.kt
@@ -1,0 +1,21 @@
+package com.shalenmathew.quotesapp.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.shalenmathew.quotesapp.domain.repository.DefaultQuoteStylePreferences
+import com.shalenmathew.quotesapp.presentation.screens.share_screen.QuoteStyle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ShareQuoteViewModel @Inject constructor(
+    private val defaultQuoteStylePreferences: DefaultQuoteStylePreferences
+): ViewModel() {
+
+    fun getDefaultQuoteStyle(): QuoteStyle{
+        return defaultQuoteStylePreferences.getDefaultQuoteStyle()
+    }
+
+    fun changeDefaultQuoteStyle(quoteStyle: QuoteStyle){
+        defaultQuoteStylePreferences.saveDefaultQuoteStyle(quoteStyle)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/util/Constants.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/util/Constants.kt
@@ -10,5 +10,5 @@ object Constants {
     val REQUEST_CODE_WRITE_STORAGE = 102
 
     val WORK_MANAGER_STATUS_NOTIFY =  "WorkManagerStatusNotify"
-
+    const val SHARED_PREFERENCES_NAME = "quotes_app_preferences"
 }


### PR DESCRIPTION
This pull request addresses Issue #39.
It introduces a checkbox that lets users set their selected quote style as the default, enhancing the overall user experience by removing the need to reselect a theme each time.
The chosen style is stored using persistent storage, ensuring the preference is preserved across app restarts.

https://github.com/user-attachments/assets/56cc4828-0dbe-4026-b8de-ea9d077aa960

