### PR TITLE
Align heart/fav icon size with send/share icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ https://github.com/user-attachments/assets/38a15a1e-b324-4355-8574-49e83cf044cd
 - 🔔 daily inspiration via notifications
 
 
-## Contribution 🤝
+## Contribution/Issues 🤝
 - If your new to open source and want to play around with contribution you can do it here or u can raise issue if you want to make any improvements or fix any bugs
+
+  ### Contribution Guide :
+ - Raise ur PR against the development branch
+ - just add a small desc to get an idea whats the issue/pr is really about
+ - THATS IT !!!
   
 - Tip for beginners : Try to fix small bugs and dont get overwhelmed by the source code , take your time... Start by making small fixes or making small changes 👍
 

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/fav_screen/FavQuoteItem.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/fav_screen/FavQuoteItem.kt
@@ -1,6 +1,5 @@
 package com.shalenmathew.quotesapp.presentation.screens.fav_screen
 
-import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -24,7 +23,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TileMode
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -33,23 +31,21 @@ import androidx.navigation.NavHostController
 import coil.compose.AsyncImage
 import com.shalenmathew.quotesapp.R
 import com.shalenmathew.quotesapp.domain.model.Quote
-import com.shalenmathew.quotesapp.presentation.screens.fav_screen.util.FavQuoteEvent
 import com.shalenmathew.quotesapp.presentation.screens.bottom_nav.Screen
+import com.shalenmathew.quotesapp.presentation.screens.fav_screen.util.FavQuoteEvent
 import com.shalenmathew.quotesapp.presentation.theme.GIFont
 import com.shalenmathew.quotesapp.presentation.theme.customBlack
 import com.shalenmathew.quotesapp.presentation.theme.customGrey
 import com.shalenmathew.quotesapp.presentation.viewmodel.FavQuoteViewModel
 
 
-
 @Composable
-fun FavQuoteItem(quote: Quote,
-                 quoteViewModel: FavQuoteViewModel,
-                 navHost: NavHostController,
-                 modifier: Modifier){
-
-    val context = LocalContext.current
-    val activity = context as ComponentActivity
+fun FavQuoteItem(
+    quote: Quote,
+    quoteViewModel: FavQuoteViewModel,
+    navHost: NavHostController,
+    modifier: Modifier
+) {
 
     val gradient = Brush.radialGradient(
         0.0f to customBlack,
@@ -63,70 +59,74 @@ fun FavQuoteItem(quote: Quote,
             .padding(horizontal = 12.dp, vertical = 5.dp)
             .clip(RoundedCornerShape(20.dp))
             .background(gradient)
-            .fillMaxSize()){
+            .fillMaxSize()
+    ) {
 
         Column(modifier = Modifier.wrapContentSize()) {
 
             AsyncImage(
                 model = R.drawable.quotation,
                 contentDescription = null,
-                modifier= Modifier
+                modifier = Modifier
 
-                    .padding(start=12.dp,top = 10.dp)
-                    .size(30.dp))
+                    .padding(start = 12.dp, top = 10.dp)
+                    .size(30.dp)
+            )
 
-            Text(text = quote.quote,
+            Text(
+                text = quote.quote,
                 fontFamily = GIFont,
                 fontWeight = FontWeight.Normal,
                 fontSize = 18.sp,
                 modifier = Modifier.padding(horizontal = 15.dp, vertical = 10.dp),
                 color = Color.White,
                 style = TextStyle(
-                    lineHeight = 40.sp // Set the line height
-                ))
+                    lineHeight = 40.sp
+                )
+            )
 
-            Spacer(modifier= Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
-            Text(text = quote.author,
+            Text(
+                text = quote.author,
                 color = Color.Gray,
-                modifier = Modifier.padding(horizontal = 15.dp))
+                modifier = Modifier.padding(horizontal = 15.dp)
+            )
 
 
 
-               Box(modifier = Modifier.wrapContentWidth()){
+            Box(modifier = Modifier.wrapContentWidth()) {
 
-                   Row(modifier = Modifier.fillMaxWidth(),
-                       horizontalArrangement = Arrangement.End)
-                   {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    AsyncImage(
+                        model = R.drawable.send,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(end = 12.dp, bottom = 10.dp)
+                            .size(35.dp)
+                            .clickable {
+                                navHost.currentBackStackEntry?.savedStateHandle?.set("quote", quote)
+                                navHost.navigate(Screen.Share.route)
+                            }
+                    )
 
-                       AsyncImage(model = R.drawable.send,
-                           contentDescription = null,
-                           modifier= Modifier
-                               .padding(end = 12.dp, bottom = 10.dp)
-                               .size(35.dp)
-                               .clickable {
+                    Spacer(modifier = Modifier.width(15.dp))
 
-                                   navHost.currentBackStackEntry?.savedStateHandle?.set("quote",quote)
-                                   navHost.navigate(Screen.Share.route)
-
-                           })
-
-                       Spacer(modifier= Modifier.width(15.dp))
-
-                       AsyncImage(model = R.drawable.heart_filled,
-                           contentDescription = null,
-                           modifier= Modifier
-                               .padding(end = 12.dp, bottom = 10.dp)
-                               .size(30.dp)
-                               .clickable {
-                                   quoteViewModel.onEvent(FavQuoteEvent.Like(quote))
-
-                               })
-                   }
-
+                    AsyncImage(
+                        model = R.drawable.heart_filled,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(end = 12.dp, bottom = 10.dp)
+                            .size(35.dp)
+                            .clickable {
+                                quoteViewModel.onEvent(FavQuoteEvent.Like(quote))
+                            }
+                    )
+                }
             }
-
         }
-
     }
 }


### PR DESCRIPTION
# Icon Alignment Fix in FavQuoteItem

## Problem
The heart icon in the favorite quotes screen was misaligned with the send icon, appearing slightly higher due to inconsistent size values.

## Solution
Standardized the icon sizes and padding values in the FavQuoteItem composable to ensure consistent alignment:
- Updated heart icon size from 30.dp to 35.dp to match send icon
- Maintained consistent padding values across both icons
