### PR TITLE
fix: sync heart icon state between Home and Favourites tabs

### DIFF
--- a/app/src/main/java/com/shalenmathew/quotesapp/data/repository/QuoteRepositoryImplementation.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/repository/QuoteRepositoryImplementation.kt
@@ -96,5 +96,9 @@ class QuoteRepositoryImplementation(private val api:QuoteApi, private val db:Quo
         db.getQuoteDao().insertLikedQuote(quote)
     }
 
+    override fun getAllLikedQuotes(): Flow<List<Quote>> {
+        return db.getQuoteDao().getAllLikedQuotes()
+    }
+
 
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/QuoteRepository.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/QuoteRepository.kt
@@ -11,4 +11,6 @@ interface QuoteRepository {
 
      suspend  fun saveLikedQuote(quote: Quote)
 
+    fun getAllLikedQuotes(): Flow<List<Quote>>
+
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/GetLikedQuotes.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/GetLikedQuotes.kt
@@ -1,0 +1,12 @@
+package com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetLikedQuotes @Inject constructor(private val quoteRepository: QuoteRepository) {
+    operator fun invoke(): Flow<List<Quote>> {
+        return quoteRepository.getAllLikedQuotes()
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/QuoteUseCase.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/QuoteUseCase.kt
@@ -2,5 +2,6 @@ package com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases
 
 data class QuoteUseCase(
     val getQuote: GetQuote,
-    val likedQuote: LikedQuote
+    val likedQuote: LikedQuote,
+    val getLikedQuotes: GetLikedQuotes
 )

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/QuoteViewModel.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/QuoteViewModel.kt
@@ -28,6 +28,7 @@ class QuoteViewModel @Inject constructor(
 
     init {
         getQuote()
+        observeLikedQuotes()
     }
 
     private fun getQuote(){
@@ -61,6 +62,21 @@ class QuoteViewModel @Inject constructor(
                }
            }
        }
+    }
+
+    private fun observeLikedQuotes() {
+        viewModelScope.launch {
+            quoteUseCase.getLikedQuotes().collect { likedQuotes ->
+                // Update the like status of quotes in the current state
+                _quoteState.value = _quoteState.value.copy(
+                    dataList = _quoteState.value.dataList.map { quote ->
+                        // Check if this quote is in the liked quotes list
+                        val isLiked = likedQuotes.any { likedQuote -> likedQuote.id == quote.id }
+                        quote.copy(liked = isLiked)
+                    }.toMutableList()
+                )
+            }
+        }
     }
 
     fun onEvent(quoteEvent: QuoteEvent){


### PR DESCRIPTION
- Add getAllLikedQuotes() method to QuoteRepository interface
- Implement getAllLikedQuotes() in QuoteRepositoryImplementation
- Create GetLikedQuotes use case to observe liked quotes from database
- Update QuoteUseCase to include GetLikedQuotes
- Add observeLikedQuotes() method to QuoteViewModel to sync like states
- Fix issue where heart icons don't update when quotes are removed from Favourites

Now when a quote is removed from Favourites, the Home page will automatically update the heart icon to unfilled state, maintaining UI consistency across tabs.