### PR TITLE
Fix default theme checkbox issue #131

### DIFF
--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/ShareScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/ShareScreen.kt
@@ -76,6 +76,7 @@ fun ShareScreen(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scrollState = rememberScrollState()
     var quoteStyleState by remember { mutableStateOf<QuoteStyle>(QuoteStyle.DefaultTheme) }
+    var defaultQuoteStyle by remember { mutableStateOf<QuoteStyle>(QuoteStyle.DefaultTheme) }
     var triggerCapture by remember { mutableStateOf(false) }
     var pendingAction by remember { mutableStateOf<String?>(null) }
 
@@ -88,7 +89,9 @@ fun ShareScreen(
     var editTarget by remember { mutableStateOf("start") }
 
     LaunchedEffect(Unit) {
-        quoteStyleState = viewModel.getDefaultQuoteStyle()
+        val defaultStyle = viewModel.getDefaultQuoteStyle()
+        quoteStyleState = defaultStyle
+        defaultQuoteStyle = defaultStyle
     }
 
     LaunchedEffect(imgBitmap, pendingAction) {
@@ -313,11 +316,11 @@ fun ShareScreen(
                             )
                             Checkbox(
                                 modifier = Modifier.align(Alignment.BottomEnd),
-                                checked = quoteStyleState == QuoteStyle.CodeSnippetTheme,
+                                checked = defaultQuoteStyle == QuoteStyle.CodeSnippetTheme,
                                 onCheckedChange = { isChecked ->
                                     if (isChecked) {
-                                        quoteStyleState = QuoteStyle.CodeSnippetTheme
-                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        defaultQuoteStyle = QuoteStyle.CodeSnippetTheme
+                                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                                     }
                                 }
                             )
@@ -352,11 +355,11 @@ fun ShareScreen(
                             )
                             Checkbox(
                                 modifier = Modifier.align(Alignment.BottomEnd),
-                                checked = quoteStyleState == QuoteStyle.bratTheme,
+                                checked = defaultQuoteStyle == QuoteStyle.bratTheme,
                                 onCheckedChange = { isChecked ->
                                     if (isChecked) {
-                                        quoteStyleState = QuoteStyle.bratTheme
-                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        defaultQuoteStyle = QuoteStyle.bratTheme
+                                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                                     }
                                 }
                             )
@@ -391,11 +394,11 @@ fun ShareScreen(
                             )
                             Checkbox(
                                 modifier = Modifier.align(Alignment.BottomEnd),
-                                checked = quoteStyleState == QuoteStyle.igorTheme,
+                                checked = defaultQuoteStyle == QuoteStyle.igorTheme,
                                 onCheckedChange = { isChecked ->
                                     if (isChecked) {
-                                        quoteStyleState = QuoteStyle.igorTheme
-                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        defaultQuoteStyle = QuoteStyle.igorTheme
+                                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                                     }
                                 }
                             )
@@ -430,11 +433,11 @@ fun ShareScreen(
                             )
                             Checkbox(
                                 modifier = Modifier.align(Alignment.BottomEnd),
-                                checked = quoteStyleState == QuoteStyle.DefaultTheme,
+                                checked = defaultQuoteStyle == QuoteStyle.DefaultTheme,
                                 onCheckedChange = { isChecked ->
                                     if (isChecked) {
-                                        quoteStyleState = QuoteStyle.DefaultTheme
-                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        defaultQuoteStyle = QuoteStyle.DefaultTheme
+                                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                                     }
                                 }
                             )
@@ -467,11 +470,11 @@ fun ShareScreen(
                             )
                             Checkbox(
                                 modifier = Modifier.align(Alignment.BottomEnd),
-                                checked = quoteStyleState == QuoteStyle.LiquidGlassTheme,
+                                checked = defaultQuoteStyle == QuoteStyle.LiquidGlassTheme,
                                 onCheckedChange = { isChecked ->
                                     if (isChecked) {
-                                        quoteStyleState = QuoteStyle.LiquidGlassTheme
-                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        defaultQuoteStyle = QuoteStyle.LiquidGlassTheme
+                                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                                     }
                                 }
                             )
@@ -531,11 +534,11 @@ fun ShareScreen(
                             )
                             Checkbox(
                                 modifier = Modifier.align(Alignment.BottomEnd),
-                                checked = quoteStyleState == QuoteStyle.ReminderTheme,
+                                checked = defaultQuoteStyle == QuoteStyle.ReminderTheme,
                                 onCheckedChange = { isChecked ->
                                     if (isChecked) {
-                                        quoteStyleState = QuoteStyle.ReminderTheme
-                                        viewModel.changeDefaultQuoteStyle(quoteStyleState)
+                                        defaultQuoteStyle = QuoteStyle.ReminderTheme
+                                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                                     }
                                 }
                             )


### PR DESCRIPTION
- Add separate defaultQuoteStyle state to track default theme independently from current applied theme
- Update all checkbox checked states to use defaultQuoteStyle instead of quoteStyleState
- Image clicks now only change current theme, checkbox clicks change default theme
- Fixes issue where checkbox incorrectly updated when applying different theme to quote

The checkbox now correctly shows which theme is set as default and only changes when user explicitly clicks checkbox to set new default theme.

Fixes. #131 