### PR TITLE
feat: Add custom quote functionality

### DIFF
--- a/app/src/main/java/com/shalenmathew/quotesapp/data/local/CustomQuoteDao.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/local/CustomQuoteDao.kt
@@ -1,0 +1,30 @@
+package com.shalenmathew.quotesapp.data.local
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CustomQuoteDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCustomQuote(quote: CustomQuote)
+
+    @Delete
+    suspend fun deleteCustomQuote(quote: CustomQuote)
+
+    @Query("SELECT * FROM custom_quotes ORDER BY createdAt DESC")
+    fun getAllCustomQuotes(): Flow<List<CustomQuote>>
+
+    @Query("""
+        SELECT * FROM custom_quotes 
+        WHERE LOWER(quote) LIKE '%' || LOWER(:query) || '%'
+        OR LOWER(author) LIKE '%' || LOWER(:query) || '%'
+        ORDER BY createdAt DESC
+    """)
+    fun searchCustomQuotes(query: String): Flow<List<CustomQuote>>
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/data/local/QuoteDatabase.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/local/QuoteDatabase.kt
@@ -2,12 +2,14 @@ package com.shalenmathew.quotesapp.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
 import com.shalenmathew.quotesapp.domain.model.Quote
 
 
-@Database(entities = [Quote::class], version = 4)
-abstract class QuoteDatabase:RoomDatabase() {
+@Database(entities = [Quote::class, CustomQuote::class], version = 5)
+abstract class QuoteDatabase : RoomDatabase() {
 
-    abstract fun getQuoteDao():QuoteDao
+    abstract fun getQuoteDao(): QuoteDao
+    abstract fun getCustomQuoteDao(): CustomQuoteDao
 
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/data/repository/CustomQuoteRepositoryImpl.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/repository/CustomQuoteRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.shalenmathew.quotesapp.data.repository
+
+import com.shalenmathew.quotesapp.data.local.QuoteDatabase
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import com.shalenmathew.quotesapp.domain.repository.CustomQuoteRepository
+import kotlinx.coroutines.flow.Flow
+
+class CustomQuoteRepositoryImpl(private val db: QuoteDatabase) : CustomQuoteRepository {
+
+    override fun getAllCustomQuotes(query: String): Flow<List<CustomQuote>> {
+        return if (query.isNotBlank()) {
+            db.getCustomQuoteDao().searchCustomQuotes(query)
+        } else {
+            db.getCustomQuoteDao().getAllCustomQuotes()
+        }
+    }
+
+    override suspend fun saveCustomQuote(quote: CustomQuote) {
+        db.getCustomQuoteDao().insertCustomQuote(quote)
+    }
+
+    override suspend fun deleteCustomQuote(quote: CustomQuote) {
+        db.getCustomQuoteDao().deleteCustomQuote(quote)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/di/AppModule.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/di/AppModule.kt
@@ -11,12 +11,18 @@ import com.shalenmathew.quotesapp.data.local.AnimationPreferencesImpl
 import com.shalenmathew.quotesapp.data.local.DefaultQuoteStylePreferencesImpl
 import com.shalenmathew.quotesapp.data.local.QuoteDatabase
 import com.shalenmathew.quotesapp.data.remote.QuoteApi
+import com.shalenmathew.quotesapp.data.repository.CustomQuoteRepositoryImpl
 import com.shalenmathew.quotesapp.data.repository.FavQuoteRepositoryImpl
 import com.shalenmathew.quotesapp.data.repository.QuoteRepositoryImplementation
 import com.shalenmathew.quotesapp.domain.repository.AnimationPreferences
+import com.shalenmathew.quotesapp.domain.repository.CustomQuoteRepository
 import com.shalenmathew.quotesapp.domain.repository.DefaultQuoteStylePreferences
 import com.shalenmathew.quotesapp.domain.repository.FavQuoteRepository
 import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
+import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.CustomQuoteUseCases
+import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.DeleteCustomQuote
+import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.GetCustomQuotes
+import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.SaveCustomQuote
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.FavLikedQuote
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.FavQuoteUseCase
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.GetFavQuote
@@ -54,7 +60,7 @@ return QuoteUseCase(getQuote = getQuote, likedQuote = likedQuote, getLikedQuotes
     @Provides
     fun providesQuoteDatabase(application: Application):QuoteDatabase{
         return Room.databaseBuilder(application,QuoteDatabase::class.java,"quote_db")
-            .addMigrations(DB_MIGRATION)
+            .addMigrations(DB_MIGRATION, DB_MIGRATION_4_5)
 //            .fallbackToDestructiveMigration(true)
             .build()
     }
@@ -62,6 +68,19 @@ return QuoteUseCase(getQuote = getQuote, likedQuote = likedQuote, getLikedQuotes
     val DB_MIGRATION = object : Migration(3, 4) {
         override fun migrate(db: SupportSQLiteDatabase) {
             db.execSQL("ALTER TABLE Quote ADD COLUMN updatedAt INTEGER NOT NULL DEFAULT 0")
+        }
+    }
+
+    val DB_MIGRATION_4_5 = object : Migration(4, 5) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("""
+            CREATE TABLE IF NOT EXISTS custom_quotes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                quote TEXT NOT NULL,
+                author TEXT NOT NULL,
+                createdAt INTEGER NOT NULL
+            )
+        """)
         }
     }
 
@@ -137,5 +156,39 @@ fun providesQuoteRepository(api:QuoteApi,db:QuoteDatabase):QuoteRepository{
     @Provides
     fun providesAnimationPreferences(): AnimationPreferences {
         return AnimationPreferencesImpl()
+    }
+
+    @Singleton
+    @Provides
+    fun providesCustomQuoteRepository(db: QuoteDatabase): CustomQuoteRepository {
+        return CustomQuoteRepositoryImpl(db)
+    }
+
+    @Singleton
+    @Provides
+    fun providesGetCustomQuotes(repository: CustomQuoteRepository): GetCustomQuotes {
+        return GetCustomQuotes(repository)
+    }
+
+    @Singleton
+    @Provides
+    fun providesSaveCustomQuote(repository: CustomQuoteRepository): SaveCustomQuote {
+        return SaveCustomQuote(repository)
+    }
+
+    @Singleton
+    @Provides
+    fun providesDeleteCustomQuote(repository: CustomQuoteRepository): DeleteCustomQuote {
+        return DeleteCustomQuote(repository)
+    }
+
+    @Singleton
+    @Provides
+    fun providesCustomQuoteUseCases(
+        getCustomQuotes: GetCustomQuotes,
+        saveCustomQuote: SaveCustomQuote,
+        deleteCustomQuote: DeleteCustomQuote
+    ): CustomQuoteUseCases {
+        return CustomQuoteUseCases(getCustomQuotes, saveCustomQuote, deleteCustomQuote)
     }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/model/CustomQuote.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/model/CustomQuote.kt
@@ -1,0 +1,21 @@
+package com.shalenmathew.quotesapp.domain.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "custom_quotes")
+data class CustomQuote(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val quote: String,
+    val author: String,
+    val createdAt: Long = System.currentTimeMillis()
+)
+
+fun CustomQuote.toQuote(): Quote = Quote(
+    id = id,
+    quote = quote,
+    author = author,
+    liked = false,
+    updatedAt = createdAt
+)

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/CustomQuoteRepository.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/CustomQuoteRepository.kt
@@ -1,0 +1,10 @@
+package com.shalenmathew.quotesapp.domain.repository
+
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import kotlinx.coroutines.flow.Flow
+
+interface CustomQuoteRepository {
+    fun getAllCustomQuotes(query: String): Flow<List<CustomQuote>>
+    suspend fun saveCustomQuote(quote: CustomQuote)
+    suspend fun deleteCustomQuote(quote: CustomQuote)
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/CustomQuoteUseCases.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/CustomQuoteUseCases.kt
@@ -1,0 +1,7 @@
+package com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases
+
+data class CustomQuoteUseCases(
+    val getCustomQuotes: GetCustomQuotes,
+    val saveCustomQuote: SaveCustomQuote,
+    val deleteCustomQuote: DeleteCustomQuote
+)

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/DeleteCustomQuote.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/DeleteCustomQuote.kt
@@ -1,0 +1,13 @@
+package com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases
+
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import com.shalenmathew.quotesapp.domain.repository.CustomQuoteRepository
+import javax.inject.Inject
+
+class DeleteCustomQuote @Inject constructor(
+    private val repository: CustomQuoteRepository
+) {
+    suspend operator fun invoke(quote: CustomQuote) {
+        repository.deleteCustomQuote(quote)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/GetCustomQuotes.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/GetCustomQuotes.kt
@@ -1,0 +1,14 @@
+package com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases
+
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import com.shalenmathew.quotesapp.domain.repository.CustomQuoteRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetCustomQuotes @Inject constructor(
+    private val repository: CustomQuoteRepository
+) {
+    operator fun invoke(query: String): Flow<List<CustomQuote>> {
+        return repository.getAllCustomQuotes(query)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/SaveCustomQuote.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/custom_quote_usecases/SaveCustomQuote.kt
@@ -1,0 +1,13 @@
+package com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases
+
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import com.shalenmathew.quotesapp.domain.repository.CustomQuoteRepository
+import javax.inject.Inject
+
+class SaveCustomQuote @Inject constructor(
+    private val repository: CustomQuoteRepository
+) {
+    suspend operator fun invoke(quote: CustomQuote) {
+        repository.saveCustomQuote(quote)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/navigation/AppNavigation.kt
@@ -9,6 +9,7 @@ import com.shalenmathew.quotesapp.presentation.screens.about_libraries_screen.Ab
 import com.shalenmathew.quotesapp.presentation.screens.fav_screen.FavScreen
 import com.shalenmathew.quotesapp.presentation.screens.home_screen.HomeScreen
 import com.shalenmathew.quotesapp.presentation.screens.bottom_nav.Screen
+import com.shalenmathew.quotesapp.presentation.screens.custom_quote.AddCustomQuoteScreen
 import com.shalenmathew.quotesapp.presentation.screens.intro_screen.SplashScreen
 import com.shalenmathew.quotesapp.presentation.screens.settings_screen.SettingsScreen
 import com.shalenmathew.quotesapp.presentation.screens.share_screen.ShareScreen
@@ -23,6 +24,7 @@ fun AppNavigation(navHost: NavHostController,paddingValues: PaddingValues){
         composable(Screen.Share.route) { ShareScreen(paddingValues, navHost) }
         composable(Screen.Settings.route) { SettingsScreen(paddingValues = paddingValues, navHost = navHost) }
         composable(Screen.AboutLibraries.route) { AboutLibrariesScreen(paddingValues = paddingValues, navHost = navHost) }
+        composable(Screen.AddCustomQuote.route) { AddCustomQuoteScreen(paddingValues = paddingValues, navHost = navHost) }
     }
 
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/bottom_nav/BottomNav.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/bottom_nav/BottomNav.kt
@@ -223,9 +223,11 @@ sealed class Screen(
     object Share: Screen("Share",false)
     object Settings: Screen("Settings",true)
     object AboutLibraries: Screen("AboutLibraries",false)
+    object AddCustomQuote: Screen("AddCustomQuote",false)
 
     companion object{
-        val values:List<Screen> = listOf(Home,Fav,Splash,Share, Settings, AboutLibraries)
+        val values:List<Screen> = listOf(Home,Fav,Splash,Share, Settings, AboutLibraries,
+            AddCustomQuote)
     }
 
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/AddCustomQuoteScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/AddCustomQuoteScreen.kt
@@ -1,0 +1,156 @@
+package com.shalenmathew.quotesapp.presentation.screens.custom_quote
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.shalenmathew.quotesapp.presentation.screens.custom_quote.util.CustomQuoteEvent
+import com.shalenmathew.quotesapp.presentation.theme.GIFont
+import com.shalenmathew.quotesapp.presentation.viewmodel.CustomQuoteViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddCustomQuoteScreen(
+    navHost: NavHostController,
+    paddingValues: PaddingValues,
+    viewModel: CustomQuoteViewModel = hiltViewModel()
+) {
+    var quoteText by remember { mutableStateOf("") }
+    var authorText by remember { mutableStateOf ("") }
+    val hapticFeedback = LocalHapticFeedback.current
+
+    Box(
+        modifier = Modifier
+            .padding(paddingValues)
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Create Custom Quote",
+                        fontFamily = GIFont
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                        navHost.popBackStack()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black,
+                    titleContentColor = Color.White
+                )
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                OutlinedTextField(
+                    value = quoteText,
+                    onValueChange = { quoteText = it },
+                    label = { Text("Quote *", color = Color.Gray) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = Color.White,
+                        unfocusedBorderColor = Color.Gray,
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White,
+                        cursorColor = Color.White
+                    ),
+                    maxLines = 8
+                )
+
+                OutlinedTextField(
+                    value = authorText,
+                    onValueChange = { authorText = it },
+                    label = { Text("Author (Optional)", color = Color.Gray) },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = Color.White,
+                        unfocusedBorderColor = Color.Gray,
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White,
+                        cursorColor = Color.White
+                    ),
+                    placeholder = { Text("Anonymous", color = Color.Gray) }
+                )
+
+                Text(
+                    "* Required field",
+                    color = Color.Gray,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+
+        FloatingActionButton(
+            onClick = {
+                if (quoteText.isNotBlank()) {
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                    viewModel.onEvent(
+                        CustomQuoteEvent.SaveQuote(
+                            quote = quoteText,
+                            author = authorText
+                        )
+                    )
+                    navHost.popBackStack()
+                }
+            },
+            containerColor = Color.White,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Save",
+                tint = Color.Black
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/CustomQuoteItem.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/CustomQuoteItem.kt
@@ -1,0 +1,109 @@
+package com.shalenmathew.quotesapp.presentation.screens.custom_quote
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.shalenmathew.quotesapp.R
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import com.shalenmathew.quotesapp.presentation.theme.GIFont
+import com.shalenmathew.quotesapp.presentation.theme.customBlack
+import com.shalenmathew.quotesapp.presentation.theme.customGrey
+
+@Composable
+fun CustomQuoteItem(
+    quote: CustomQuote,
+    onShareClick: (CustomQuote) -> Unit,
+    onDeleteClick: (CustomQuote) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val gradient = Brush.radialGradient(
+        0.0f to customBlack,
+        1.0f to customGrey,
+        radius = 600.0f,
+        tileMode = TileMode.Repeated
+    )
+
+    Box(
+        modifier = modifier
+            .padding(horizontal = 12.dp, vertical = 5.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(gradient)
+            .fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.wrapContentSize()) {
+            AsyncImage(
+                model = R.drawable.quotation,
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(start = 12.dp, top = 10.dp)
+                    .size(30.dp)
+            )
+
+            Text(
+                text = quote.quote,
+                fontFamily = GIFont,
+                fontWeight = FontWeight.Normal,
+                fontSize = 18.sp,
+                modifier = Modifier.padding(horizontal = 15.dp, vertical = 10.dp),
+                color = Color.White,
+                style = TextStyle(lineHeight = 40.sp)
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = quote.author,
+                color = Color.Gray,
+                modifier = Modifier.padding(horizontal = 15.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                AsyncImage(
+                    model = R.drawable.send,
+                    contentDescription = "Share",
+                    modifier = Modifier
+                        .padding(end = 12.dp, bottom = 10.dp)
+                        .size(35.dp)
+                        .clickable { onShareClick(quote) }
+                )
+
+                Spacer(modifier = Modifier.width(15.dp))
+
+                AsyncImage(
+                    model = R.drawable.heart_filled,
+                    contentDescription = "Delete",
+                    modifier = Modifier
+                        .padding(end = 12.dp, bottom = 10.dp)
+                        .size(35.dp)
+                        .clickable { onDeleteClick(quote) }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/util/CustomQuoteEvent.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/util/CustomQuoteEvent.kt
@@ -1,0 +1,8 @@
+package com.shalenmathew.quotesapp.presentation.screens.custom_quote.util
+
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+
+sealed class CustomQuoteEvent {
+    data class SaveQuote(val quote: String, val author: String) : CustomQuoteEvent()
+    data class DeleteQuote(val quote: CustomQuote) : CustomQuoteEvent()
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/util/CustomQuoteState.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/util/CustomQuoteState.kt
@@ -1,0 +1,9 @@
+package com.shalenmathew.quotesapp.presentation.screens.custom_quote.util
+
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+
+data class CustomQuoteState(
+    val customQuotes: List<CustomQuote> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String = ""
+)

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/util/DeleteConfirmationDialog.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/custom_quote/util/DeleteConfirmationDialog.kt
@@ -1,0 +1,99 @@
+package com.shalenmathew.quotesapp.presentation.screens.custom_quote.util
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.shalenmathew.quotesapp.presentation.theme.GIFont
+import com.shalenmathew.quotesapp.presentation.theme.customBlack
+import com.shalenmathew.quotesapp.presentation.theme.customGrey
+
+@Composable
+fun DeleteConfirmationDialog(
+    modifier: Modifier = Modifier,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.7f))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onDismiss
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(20.dp))
+                .background(customBlack)
+                .padding(24.dp)
+                .clickable(enabled = false, onClick = {}),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Delete Quote?",
+                fontFamily = GIFont,
+                fontSize = 22.sp,
+                color = Color.White
+            )
+            Text(
+                text = "This action cannot be undone.",
+                fontSize = 16.sp,
+                color = Color.Gray,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                Text(
+                    text = "Cancel",
+                    fontFamily = GIFont,
+                    fontSize = 18.sp,
+                    color = Color.White,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable(onClick = onDismiss)
+                        .background(customGrey)
+                        .padding(horizontal = 24.dp, vertical = 10.dp)
+                )
+
+                Text(
+                    text = "Confirm",
+                    fontFamily = GIFont,
+                    fontSize = 18.sp,
+                    color = Color.Red.copy(alpha = 0.9f),
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable(onClick = onConfirm)
+                        .background(Color.Red.copy(alpha = 0.2f))
+                        .padding(horizontal = 24.dp, vertical = 10.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/CustomQuoteViewModel.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/CustomQuoteViewModel.kt
@@ -1,0 +1,57 @@
+package com.shalenmathew.quotesapp.presentation.viewmodel
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shalenmathew.quotesapp.domain.model.CustomQuote
+import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.CustomQuoteUseCases
+import com.shalenmathew.quotesapp.presentation.screens.custom_quote.util.CustomQuoteEvent
+import com.shalenmathew.quotesapp.presentation.screens.custom_quote.util.CustomQuoteState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CustomQuoteViewModel @Inject constructor(
+    private val customQuoteUseCases: CustomQuoteUseCases
+) : ViewModel() {
+
+    private val _state = mutableStateOf(CustomQuoteState())
+    val state = _state
+
+    init {
+        getCustomQuotes()
+    }
+
+    private fun getCustomQuotes() {
+        _state.value = _state.value.copy(isLoading = true)
+
+        viewModelScope.launch {
+            customQuoteUseCases.getCustomQuotes("").collect { quotes ->
+                _state.value = _state.value.copy(
+                    customQuotes = quotes,
+                    isLoading = false
+                )
+            }
+        }
+    }
+
+    fun onEvent(event: CustomQuoteEvent) {
+        when (event) {
+            is CustomQuoteEvent.SaveQuote -> {
+                viewModelScope.launch {
+                    val customQuote = CustomQuote(
+                        quote = event.quote,
+                        author = event.author.ifBlank { "Anonymous" }
+                    )
+                    customQuoteUseCases.saveCustomQuote(customQuote)
+                }
+            }
+            is CustomQuoteEvent.DeleteQuote -> {
+                viewModelScope.launch {
+                    customQuoteUseCases.deleteCustomQuote(event.quote)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the ability for users to create, view, and delete their own custom quotes.

Key changes include:
- A new "Add Custom Quote" screen for inputting quote text and an optional author.
- Integration of custom quotes into a new "Custom" tab on the Favorites screen.
- A floating action button (+) to navigate to the creation screen.
- Implementation of Room database entities, DAO, and repository for storing and managing custom quotes.
- Addition of a confirmation dialog for deleting quotes.
- ViewModel and UseCases to handle the business logic for creating, fetching, and deleting custom quotes.
- A new database migration to add the `custom_quotes` table.

Closes #149