### PR TITLE
Add ArtisanCard theme: new composable, style mapping, and persistence

### DIFF
--- a/app/src/main/java/com/shalenmathew/quotesapp/data/local/DefaultQuoteStylePreferencesImpl.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/local/DefaultQuoteStylePreferencesImpl.kt
@@ -18,6 +18,8 @@ class DefaultQuoteStylePreferencesImpl @Inject constructor(
 //            is QuoteStyle.SpotifyTheme -> "SpotifyTheme"
             is QuoteStyle.bratTheme -> "bratTheme"
             is QuoteStyle.igorTheme -> "igorTheme"
+            is QuoteStyle.CardImageTheme -> "CardImageTheme"
+            is QuoteStyle.ArtisanCardTheme -> "ArtisanCardTheme"
             QuoteStyle.ReminderTheme -> "ReminderTheme"
         }
         sharedPreferences.edit {
@@ -28,6 +30,8 @@ class DefaultQuoteStylePreferencesImpl @Inject constructor(
     override fun getDefaultQuoteStyle(): QuoteStyle {
         return when (sharedPreferences.getString(QUOTE_STYLE_KEY, "DefaultTheme")) {
             "CodeSnippetTheme" -> QuoteStyle.CodeSnippetTheme
+            "CardImageTheme" -> QuoteStyle.CardImageTheme
+            "ArtisanCardTheme" -> QuoteStyle.ArtisanCardTheme
 //            "SpotifyTheme" -> QuoteStyle.SpotifyTheme
             "bratTheme" -> QuoteStyle.bratTheme
             "igorTheme" -> QuoteStyle.igorTheme

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/ShareScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/ShareScreen.kt
@@ -45,6 +45,9 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -60,6 +63,8 @@ import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.D
 import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.IgorScreen
 import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.LiquidGlassScreen
 import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.ReminderStyle
+import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.CardImageStyle
+import com.shalenmathew.quotesapp.presentation.screens.share_screen.components.ArtisanCardStyle
 import com.shalenmathew.quotesapp.presentation.theme.GIFont
 import com.shalenmathew.quotesapp.presentation.viewmodel.ShareQuoteViewModel
 
@@ -84,6 +89,12 @@ fun ShareScreen(
     var liquidEndColor by remember { mutableStateOf(Color(0xFF0022BB)) }
     var showColorPicker by remember { mutableStateOf(false) }
     var editTarget by remember { mutableStateOf("start") }
+    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        selectedImageUri = uri
+    }
 
     LaunchedEffect(Unit) {
         val defaultStyle = viewModel.getDefaultQuoteStyle()
@@ -133,6 +144,8 @@ fun ShareScreen(
                             color1 = liquidStartColor,  // from ShareScreen state
                             color2 = liquidEndColor     // from ShareScreen state
                         )
+                        QuoteStyle.CardImageTheme -> CardImageStyle(Modifier, quote, selectedImageUri)
+                        QuoteStyle.ArtisanCardTheme -> ArtisanCardStyle(Modifier, quote, selectedImageUri)
                         QuoteStyle.ReminderTheme -> ReminderStyle(Modifier, quote)
                     }
                 }
@@ -194,6 +207,19 @@ fun ShareScreen(
                         .clickable {
                             showSheet = true
                         })
+
+                // When Card Image or Artisan Card theme is active, show an icon to pick an image from gallery
+                if (quoteStyleState == QuoteStyle.CardImageTheme || quoteStyleState == QuoteStyle.ArtisanCardTheme) {
+                    Image(
+                        painter = painterResource(R.drawable.sample3),
+                        contentDescription = "Pick background image",
+                        modifier = Modifier.size(28.dp)
+                            .clickable {
+                                // Launch image picker
+                                imagePickerLauncher.launch("image/*")
+                            }
+                    )
+                }
 
                 Image(
                     painter = painterResource(R.drawable.downloads), contentDescription = null,
@@ -319,6 +345,40 @@ fun ShareScreen(
                     },
                     onSetDefault = {
                         defaultQuoteStyle = QuoteStyle.DefaultTheme
+                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
+                    }
+                )
+
+                // Card Image Theme (new)
+                ThemeItem(
+                    title = "Card Image",
+                    drawableRes = R.drawable.sample3,
+                    quoteStyle = QuoteStyle.CardImageTheme,
+                    isSelected = defaultQuoteStyle == QuoteStyle.CardImageTheme,
+                    contentScale = ContentScale.Crop,
+                    onThemeClick = {
+                        quoteStyleState = QuoteStyle.CardImageTheme
+                        showSheet = false
+                    },
+                    onSetDefault = {
+                        defaultQuoteStyle = QuoteStyle.CardImageTheme
+                        viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
+                    }
+                )
+
+                // Artisan Card Theme (new)
+                ThemeItem(
+                    title = "Artisan Card",
+                    drawableRes = R.drawable.sample3,
+                    quoteStyle = QuoteStyle.ArtisanCardTheme,
+                    isSelected = defaultQuoteStyle == QuoteStyle.ArtisanCardTheme,
+                    contentScale = ContentScale.Crop,
+                    onThemeClick = {
+                        quoteStyleState = QuoteStyle.ArtisanCardTheme
+                        showSheet = false
+                    },
+                    onSetDefault = {
+                        defaultQuoteStyle = QuoteStyle.ArtisanCardTheme
                         viewModel.changeDefaultQuoteStyle(defaultQuoteStyle)
                     }
                 )

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/components/CustomQuotesThemes.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/components/CustomQuotesThemes.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import coil.compose.AsyncImage
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
@@ -409,6 +410,144 @@ fun LiquidGlassScreen(
                 textAlign = TextAlign.Center
             )
 
+        }
+    }
+}
+
+/** CARD WITH IMAGE THEME */
+@Composable
+fun CardImageStyle(modifier: Modifier, quote: Quote, imageModel: Any?) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color.LightGray)
+            .wrapContentSize(Alignment.Center)
+            .padding(12.dp)
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 40.dp, vertical = 30.dp)
+                .shadow(
+                    elevation = 16.dp,
+                    shape = RoundedCornerShape(12.dp),
+                    ambientColor = Color.Black.copy(alpha = 0.6f),
+                    spotColor = Color.Black.copy(alpha = 0.6f)
+                ),
+            shape = RoundedCornerShape(12.dp),
+            elevation = CardDefaults.cardElevation(8.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                AsyncImage(
+                    model = imageModel ?: R.drawable.sample3,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                    contentScale = ContentScale.Crop
+                )
+
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        text = quote.quote,
+                        fontSize = 18.sp,
+                        lineHeight = 30.sp,
+                        color = Color.Black,
+                        fontFamily = FontFamily(Font(R.font.glaciaiindifference_regular)),
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .align(Alignment.Start),
+                        textAlign = TextAlign.Start
+                    )
+
+                    Text(
+                        text = quote.author,
+                        fontSize = 14.sp,
+                        color = DarkerGrey,
+                        modifier = Modifier
+                            .align(Alignment.Start)
+                            .padding(top = 10.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** ARTISAN CARD THEME (new) */
+@Composable
+fun ArtisanCardStyle(modifier: Modifier, quote: Quote, imageModel: Any?) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color(0xFFE9E9EA)) // light grey background for the screen
+            .wrapContentSize(Alignment.Center)
+            .padding(12.dp)
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 36.dp, vertical = 30.dp)
+                .shadow(
+                    elevation = 18.dp,
+                    shape = RoundedCornerShape(20.dp),
+                    ambientColor = Color.Black.copy(alpha = 0.5f),
+                    spotColor = Color.Black.copy(alpha = 0.5f)
+                ),
+            shape = RoundedCornerShape(20.dp),
+            elevation = CardDefaults.cardElevation(10.dp),
+            colors = CardDefaults.cardColors(containerColor = Color(0xFF2077FF)) // bright blue card
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                // top image area (rounded inside card)
+                AsyncImage(
+                    model = imageModel ?: R.drawable.sample3,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(170.dp)
+                        .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)),
+                    contentScale = ContentScale.Crop
+                )
+
+                // content area with quote and author
+                Column(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(18.dp)) {
+
+                    Text(
+                        text = quote.quote.uppercase(),
+                        fontSize = 14.sp,
+                        lineHeight = 20.sp,
+                        color = Color.White,
+                        fontFamily = FontFamily(Font(R.font.glaciaiindifference_regular)),
+                        modifier = Modifier
+                            .align(Alignment.Start)
+                    )
+
+                    Text(
+                        text = quote.author,
+                        fontSize = 18.sp,
+                        color = Color.White,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier
+                            .padding(top = 12.dp)
+                            .align(Alignment.Start)
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // decorative barcode-like box at bottom left
+                    Box(
+                        modifier = Modifier
+                            .height(28.dp)
+                            .width(160.dp)
+                            .background(Color.Black, shape = RoundedCornerShape(4.dp))
+                    ) {}
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/util.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/share_screen/util.kt
@@ -133,6 +133,10 @@ sealed class QuoteStyle()
     object igorTheme : QuoteStyle()
 
     object ReminderTheme : QuoteStyle()
+    // New theme: Card with user-selectable image on a grey background
+    object CardImageTheme : QuoteStyle()
+    // Artisan card style: blue rounded card on grey background with an image area
+    object ArtisanCardTheme : QuoteStyle()
 
 }
 


### PR DESCRIPTION
1. Added new QuoteStyle value:

- ArtisanCardTheme in [util.kt]
2. Implemented the UI/composable:

- ArtisanCardStyle in [CustomQuotesThemes.kt]

- Renders a grey screen background, rounded blue card, top image area (user-selectable), quote text and author, and a small decorative bar.

3. Wired selection + preview + image picker:

- [ShareScreen.kt] — added ThemeItem entry for "Artisan Card", render mapping for ArtisanCardTheme, and enabled the gallery picker icon when this theme is active.

4. Persisted the theme:

- [DefaultQuoteStylePreferencesImpl.kt] — added save/get mapping strings so the theme can be set as default and lasts across sessions.