### PR TITLE
feat: add interactive like button to widget (#127)

### DIFF
--- a/app/src/androidTest/java/com/shalenmathew/quotesapp/local/QuotesDaoTest.kt
+++ b/app/src/androidTest/java/com/shalenmathew/quotesapp/local/QuotesDaoTest.kt
@@ -9,6 +9,7 @@ import junit.framework.ComparisonFailure
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -123,7 +124,15 @@ class QuotesDaoTest {
 
     }
 
+    @Test
+    fun test_getQuoteById() = runTest {
+        val quote = Quote(1, "quote", "author", false)
+        quoteDao.insertQuoteList(listOf(quote))
 
+        val result = quoteDao.getQuoteById(1)
+
+        assertEquals("quote", result?.quote)
+    }
 
     @After
     fun tearDown(){

--- a/app/src/main/java/com/shalenmathew/quotesapp/data/local/GlanceWidgetManagerImpl.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/local/GlanceWidgetManagerImpl.kt
@@ -1,0 +1,43 @@
+package com.shalenmathew.quotesapp.data.local
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.appwidget.updateAll
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import com.shalenmathew.quotesapp.domain.repository.GlanceWidgetManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlin.reflect.KClass
+
+class GlanceWidgetManagerImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : GlanceWidgetManager {
+
+    private val glanceAppWidgetManager = GlanceAppWidgetManager(context)
+
+    override suspend fun <T : GlanceAppWidget> getWidgetIds(
+        widgetClass: KClass<T>
+    ): List<GlanceId> {
+        return glanceAppWidgetManager.getGlanceIds(widgetClass.java)
+    }
+
+    override suspend fun updateWidgetState(
+        glanceId: GlanceId,
+        updateBlock: (Preferences) -> Preferences
+    ) {
+        updateAppWidgetState(
+            context,
+            PreferencesGlanceStateDefinition,
+            glanceId,
+            updateBlock
+        )
+    }
+
+    override suspend fun <T : GlanceAppWidget> updateAllWidgets(widget: T) {
+        widget.updateAll(context)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/data/local/QuoteDao.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/local/QuoteDao.kt
@@ -18,6 +18,12 @@ interface QuoteDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertLikedQuote(quote: Quote)
 
+    @Query("SELECT * FROM Quote WHERE id = :id LIMIT 1")
+    suspend fun getQuoteById(id: Int): Quote?
+
+    @Query("SELECT * FROM Quote ORDER BY id DESC LIMIT 1")
+    suspend fun getLatestQuote(): Quote?
+
     @Delete
     suspend fun deleteQuote(quote: Quote)
 

--- a/app/src/main/java/com/shalenmathew/quotesapp/data/repository/QuoteRepositoryImplementation.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/repository/QuoteRepositoryImplementation.kt
@@ -40,6 +40,9 @@ class QuoteRepositoryImplementation(private val api: QuoteApi, private val db: Q
                 val quotesListDef = async { api.getQuotesList().map { it.toQuote() } }
                 val qotDef = async { api.getQuoteOfTheDay().map { it.toQuote() } }
 
+                val quotesList = quotesListDef.await()
+                val qot = qotDef.await()
+
                 val currList = db.getQuoteDao().getAllQuotes()
 
                 currList.onEach {
@@ -50,9 +53,6 @@ class QuoteRepositoryImplementation(private val api: QuoteApi, private val db: Q
                         // so u don't need to launch another coroutine
                     }
                 }
-
-                val quotesList = quotesListDef.await()
-                val qot = qotDef.await()
 
                 quotesList.let { list ->
                     db.getQuoteDao().insertQuoteList(list)
@@ -108,5 +108,9 @@ class QuoteRepositoryImplementation(private val api: QuoteApi, private val db: Q
         return db.getQuoteDao().getAllLikedQuotes()
     }
 
+    override suspend fun getQuoteById(id: Int): Quote? =
+        db.getQuoteDao().getQuoteById(id)
 
+    override suspend fun getLatestQuote(): Quote? =
+        db.getQuoteDao().getLatestQuote()
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/data/repository/WidgetRepositoryImpl.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/data/repository/WidgetRepositoryImpl.kt
@@ -1,0 +1,60 @@
+package com.shalenmathew.quotesapp.data.repository
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.GlanceWidgetManager
+import com.shalenmathew.quotesapp.domain.repository.WidgetRepository
+import com.shalenmathew.quotesapp.presentation.widget.QuotesWidgetObj
+import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_ID_KEY
+import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_KEY
+import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_LIKED_KEY
+import javax.inject.Inject
+
+class WidgetRepositoryImpl @Inject constructor(
+    private val glanceWidgetManager: GlanceWidgetManager
+) : WidgetRepository {
+
+    override suspend fun updateWidget(quote: Quote): Result<Unit> =
+        withValidQuoteId(quote) { quoteId ->
+            updateWidgets { prefs ->
+                prefs.toMutablePreferences().apply {
+                    setQuoteData(quote, quoteId)
+                }
+            }
+        }
+
+    override suspend fun updateWidgetIfSameOrEmpty(quote: Quote): Result<Unit> =
+        withValidQuoteId(quote) { quoteId ->
+            updateWidgets { prefs ->
+                val currentQuoteId = prefs[WIDGET_QUOTE_ID_KEY]
+                if (currentQuoteId == null || currentQuoteId == quoteId) {
+                    prefs.toMutablePreferences().apply { setQuoteData(quote, quoteId) }
+                } else {
+                    prefs
+                }
+            }
+        }
+
+    private suspend fun updateWidgets(
+        updateState: (Preferences) -> Preferences
+    ): Result<Unit> = runCatching {
+        val widgetIds = glanceWidgetManager.getWidgetIds(QuotesWidgetObj::class)
+        widgetIds.forEach { glanceId ->
+            glanceWidgetManager.updateWidgetState(glanceId, updateState)
+        }
+        glanceWidgetManager.updateAllWidgets(QuotesWidgetObj)
+    }
+
+    private inline fun <T> withValidQuoteId(
+        quote: Quote,
+        block: (Int) -> Result<T>
+    ): Result<T> = quote.id?.let(block)
+        ?: Result.failure(IllegalArgumentException("Quote id is null"))
+
+    private fun MutablePreferences.setQuoteData(quote: Quote, quoteId: Int) {
+        this[WIDGET_QUOTE_KEY] = quote.quote
+        this[WIDGET_QUOTE_ID_KEY] = quoteId
+        this[WIDGET_QUOTE_LIKED_KEY] = quote.liked
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/di/AppModule.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/di/AppModule.kt
@@ -9,16 +9,20 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.shalenmathew.quotesapp.BuildConfig
 import com.shalenmathew.quotesapp.data.local.AnimationPreferencesImpl
 import com.shalenmathew.quotesapp.data.local.DefaultQuoteStylePreferencesImpl
+import com.shalenmathew.quotesapp.data.local.GlanceWidgetManagerImpl
 import com.shalenmathew.quotesapp.data.local.QuoteDatabase
 import com.shalenmathew.quotesapp.data.remote.QuoteApi
 import com.shalenmathew.quotesapp.data.repository.CustomQuoteRepositoryImpl
 import com.shalenmathew.quotesapp.data.repository.FavQuoteRepositoryImpl
 import com.shalenmathew.quotesapp.data.repository.QuoteRepositoryImplementation
+import com.shalenmathew.quotesapp.data.repository.WidgetRepositoryImpl
 import com.shalenmathew.quotesapp.domain.repository.AnimationPreferences
 import com.shalenmathew.quotesapp.domain.repository.CustomQuoteRepository
 import com.shalenmathew.quotesapp.domain.repository.DefaultQuoteStylePreferences
 import com.shalenmathew.quotesapp.domain.repository.FavQuoteRepository
+import com.shalenmathew.quotesapp.domain.repository.GlanceWidgetManager
 import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
+import com.shalenmathew.quotesapp.domain.repository.WidgetRepository
 import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.CustomQuoteUseCases
 import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.DeleteCustomQuote
 import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.GetCustomQuotes
@@ -26,6 +30,7 @@ import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.SaveCust
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.FavLikedQuote
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.FavQuoteUseCase
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.GetFavQuote
+import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.GetLatestQuote
 import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.GetLikedQuotes
 import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.GetQuote
 import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.LikedQuote
@@ -52,9 +57,19 @@ object AppModule {
 
     @Singleton
     @Provides
-fun providesQuoteUsecase(getQuote: GetQuote, likedQuote: LikedQuote, getLikedQuotes: GetLikedQuotes): QuoteUseCase {
-return QuoteUseCase(getQuote = getQuote, likedQuote = likedQuote, getLikedQuotes = getLikedQuotes)
-}
+    fun providesQuoteUsecase(
+            getQuote: GetQuote,
+            likedQuote: LikedQuote,
+            getLikedQuotes: GetLikedQuotes,
+            getLatestQuote: GetLatestQuote
+    ): QuoteUseCase {
+        return QuoteUseCase(
+            getQuote = getQuote,
+            likedQuote = likedQuote,
+            getLikedQuotes = getLikedQuotes,
+            getLatestQuote = getLatestQuote
+        )
+    }
 
     @Singleton
     @Provides
@@ -190,5 +205,17 @@ fun providesQuoteRepository(api:QuoteApi,db:QuoteDatabase):QuoteRepository{
         deleteCustomQuote: DeleteCustomQuote
     ): CustomQuoteUseCases {
         return CustomQuoteUseCases(getCustomQuotes, saveCustomQuote, deleteCustomQuote)
+    }
+
+    @Provides
+    @Singleton
+    fun provideWidgetManager(@ApplicationContext context: Context): GlanceWidgetManager {
+        return GlanceWidgetManagerImpl(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideWidgetRepository(glanceWidgetManager: GlanceWidgetManager): WidgetRepository {
+        return WidgetRepositoryImpl(glanceWidgetManager)
     }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/GlanceWidgetManager.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/GlanceWidgetManager.kt
@@ -1,0 +1,15 @@
+package com.shalenmathew.quotesapp.domain.repository
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import kotlin.reflect.KClass
+
+interface GlanceWidgetManager {
+    suspend fun <T : GlanceAppWidget> getWidgetIds(widgetClass: KClass<T>): List<GlanceId>
+    suspend fun <T : GlanceAppWidget> updateAllWidgets(widget: T)
+    suspend fun updateWidgetState(
+        glanceId: GlanceId,
+        updateBlock: (Preferences) -> Preferences
+    )
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/QuoteRepository.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/QuoteRepository.kt
@@ -9,8 +9,11 @@ interface QuoteRepository {
 
     fun getQuote(): Flow<Resource<QuoteHome>>
 
-     suspend  fun saveLikedQuote(quote: Quote)
+    suspend fun saveLikedQuote(quote: Quote)
 
     fun getAllLikedQuotes(): Flow<List<Quote>>
 
+    suspend fun getQuoteById(id: Int): Quote?
+
+    suspend fun getLatestQuote(): Quote?
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/WidgetRepository.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/repository/WidgetRepository.kt
@@ -1,0 +1,8 @@
+package com.shalenmathew.quotesapp.domain.repository
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+
+interface WidgetRepository {
+    suspend fun updateWidget(quote: Quote): Result<Unit>
+    suspend fun updateWidgetIfSameOrEmpty(quote: Quote): Result<Unit>
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/GetLatestQuote.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/GetLatestQuote.kt
@@ -1,0 +1,11 @@
+package com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
+import javax.inject.Inject
+
+class GetLatestQuote @Inject constructor(private val quoteRepository: QuoteRepository) {
+    suspend operator fun invoke(): Quote? {
+        return quoteRepository.getLatestQuote()
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/LikedQuote.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/LikedQuote.kt
@@ -14,4 +14,9 @@ class LikedQuote @Inject constructor(val quoteRepository: QuoteRepository) {
 
         return updatedQuote
     }
+
+    suspend operator fun invoke(quoteId: Int): Quote? {
+        val quote = quoteRepository.getQuoteById(quoteId) ?: return null
+        return invoke(quote)
+    }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/QuoteUseCase.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/QuoteUseCase.kt
@@ -3,5 +3,6 @@ package com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases
 data class QuoteUseCase(
     val getQuote: GetQuote,
     val likedQuote: LikedQuote,
-    val getLikedQuotes: GetLikedQuotes
+    val getLikedQuotes: GetLikedQuotes,
+    val getLatestQuote: GetLatestQuote,
 )

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetIfSameOrEmptyUseCase.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetIfSameOrEmptyUseCase.kt
@@ -1,0 +1,13 @@
+package com.shalenmathew.quotesapp.domain.usecases.widget
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.WidgetRepository
+import javax.inject.Inject
+
+class UpdateWidgetIfSameOrEmptyUseCase @Inject constructor(
+    private val widgetRepository: WidgetRepository
+) {
+    suspend operator fun invoke(quote: Quote): Result<Unit> {
+        return widgetRepository.updateWidgetIfSameOrEmpty(quote)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetUseCase.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetUseCase.kt
@@ -1,0 +1,13 @@
+package com.shalenmathew.quotesapp.domain.usecases.widget
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.WidgetRepository
+import javax.inject.Inject
+
+class UpdateWidgetUseCase @Inject constructor(
+    private val widgetRepository: WidgetRepository
+) {
+    suspend operator fun invoke(quote: Quote): Result<Unit> {
+        return widgetRepository.updateWidget(quote)
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/FavQuoteViewModel.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/FavQuoteViewModel.kt
@@ -1,9 +1,11 @@
 package com.shalenmathew.quotesapp.presentation.viewmodel
 
+import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.shalenmathew.quotesapp.domain.usecases.fav_screen_usecases.FavQuoteUseCase
+import com.shalenmathew.quotesapp.domain.usecases.widget.UpdateWidgetIfSameOrEmptyUseCase
 import com.shalenmathew.quotesapp.presentation.screens.fav_screen.util.FavQuoteEvent
 import com.shalenmathew.quotesapp.presentation.screens.fav_screen.util.FavQuoteState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,8 +15,14 @@ import javax.inject.Inject
 
 
 @HiltViewModel
-class FavQuoteViewModel@Inject constructor(private val favQuoteUseCase: FavQuoteUseCase): ViewModel() {
+class FavQuoteViewModel @Inject constructor(
+    private val favQuoteUseCase: FavQuoteUseCase,
+    private val updateWidgetIfSameOrEmptyUseCase: UpdateWidgetIfSameOrEmptyUseCase
+): ViewModel() {
 
+    companion object {
+        private const val TAG = "FavQuoteViewModel"
+    }
 
     private val _favQuoteState = mutableStateOf(FavQuoteState())
     val favQuoteState = _favQuoteState
@@ -43,6 +51,8 @@ class FavQuoteViewModel@Inject constructor(private val favQuoteUseCase: FavQuote
                 viewModelScope.launch {
 
                     val updatedQuote = favQuoteUseCase.favLikedQuote(quoteEvent.quote)
+                    updateWidgetIfSameOrEmptyUseCase(updatedQuote)
+                        .onFailure { Log.w(TAG, "Widget update failed: ${it.message}") }
 
                     _favQuoteState.value=_favQuoteState.value.copy(dataList = _favQuoteState.value.dataList.map { quote->
                         if(quote.id==updatedQuote.id) updatedQuote else quote

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/QuoteViewModel.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/QuoteViewModel.kt
@@ -1,20 +1,15 @@
 package com.shalenmathew.quotesapp.presentation.viewmodel
 
-import android.content.Context
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.QuoteUseCase
+import com.shalenmathew.quotesapp.domain.usecases.widget.UpdateWidgetIfSameOrEmptyUseCase
 import com.shalenmathew.quotesapp.presentation.screens.home_screen.util.QuoteEvent
 import com.shalenmathew.quotesapp.presentation.screens.home_screen.util.QuoteState
-import com.shalenmathew.quotesapp.util.Constants
 import com.shalenmathew.quotesapp.util.Resource
-import com.shalenmathew.quotesapp.util.getSavedWidgetQuote
-import com.shalenmathew.quotesapp.util.saveWidgetQuote
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,9 +17,12 @@ import javax.inject.Inject
 @HiltViewModel
 class QuoteViewModel @Inject constructor(
     private val quoteUseCase: QuoteUseCase,
-    @ApplicationContext private  val context: Context
+    private val updateWidgetIfSameOrEmptyUseCase: UpdateWidgetIfSameOrEmptyUseCase,
 ):ViewModel()
 {
+    companion object {
+        private const val TAG = "QuoteViewModel"
+    }
 
     private val _quoteState = mutableStateOf(QuoteState())
     val quoteState = _quoteState
@@ -43,7 +41,7 @@ class QuoteViewModel @Inject constructor(
                when(it){
 
                   is Resource.Success->{
-                      Log.d("TAG","from viewmodel, fetched dat succesfully " + it.data?.quotesList[0].toString() )
+                      Log.d(TAG,"from viewmodel, fetched data successfully " + it.data?.quotesList[0].toString() )
 
                       it.data?.let { data->
                           // saving in state
@@ -51,8 +49,9 @@ class QuoteViewModel @Inject constructor(
                               qot = data.quotesOfTheDay[0], isLoading = false, error = "")
 
                           val firstQuote = data.quotesList.firstOrNull()
-                          if(context.getSavedWidgetQuote().firstOrNull().equals(Constants.NO_QUOTE_SAVED_YET)){
-                              context.saveWidgetQuote(firstQuote?.quote?:Constants.NO_QUOTE_SAVED_YET)
+                          firstQuote?.let { quote ->
+                              updateWidgetIfSameOrEmptyUseCase(quote)
+                                  .onFailure { Log.w(TAG, "Widget update failed: ${it.message}") }
                           }
 
                       } ?:{
@@ -93,8 +92,9 @@ class QuoteViewModel @Inject constructor(
 
             is QuoteEvent.Like -> {
                 viewModelScope.launch {
-//                    quoteUseCase.likedQuote(quoteEvent.quote)
                     val updatedQuote = quoteUseCase.likedQuote(quoteEvent.quote)
+                    updateWidgetIfSameOrEmptyUseCase(updatedQuote)
+                        .onFailure { Log.w(TAG, "Widget update failed: ${it.message}") }
 
                     _quoteState.value=_quoteState.value.copy(dataList = _quoteState.value.dataList.map { quote->
                         if(quote.id==updatedQuote.id) updatedQuote else quote

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/QuotesWidgetReceiver.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/QuotesWidgetReceiver.kt
@@ -1,0 +1,52 @@
+package com.shalenmathew.quotesapp.presentation.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.util.Log
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import com.shalenmathew.quotesapp.presentation.workmanager.widget.WidgetWorkManager
+
+class QuotesWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget: GlanceAppWidget = QuotesWidgetObj
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        enqueueWidgetUpdate(context)
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        enqueueWidgetUpdate(context)
+    }
+
+    private fun enqueueWidgetUpdate(context: Context) {
+        runCatching {
+            val workRequest = OneTimeWorkRequestBuilder<WidgetWorkManager>()
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WIDGET_UPDATE_WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                workRequest
+            )
+        }.onFailure { exception ->
+            Log.e(TAG, "Failed to enqueue widget update", exception)
+        }
+    }
+
+    companion object {
+        private const val TAG = "QuotesWidgetReceiver"
+        private const val WIDGET_UPDATE_WORK_NAME = "quotes_widget_update"
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/ToggleLikeActionCallback.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/ToggleLikeActionCallback.kt
@@ -1,0 +1,39 @@
+package com.shalenmathew.quotesapp.presentation.widget
+
+import android.content.Context
+import android.util.Log
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.ActionCallback
+import dagger.hilt.android.EntryPointAccessors
+
+class ToggleLikeActionCallback : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters
+    ) {
+        val quoteId = parameters[WidgetKeys.quoteIdKey] ?: return
+
+        runCatching {
+            val entryPoint = EntryPointAccessors.fromApplication(
+                context,
+                WidgetEntryPoint::class.java
+            )
+
+            val likedQuote = entryPoint.likedQuote()(quoteId) ?: run {
+                Log.w(TAG, "Unable to like the quote with id: $quoteId")
+                return
+            }
+
+            entryPoint.updateWidgetUseCase()(likedQuote)
+                .onFailure { Log.w(TAG, "Widget update failed: ${it.message}") }
+        }.onFailure {
+            Log.e(TAG, "Failed to toggle like for quote $quoteId: ${it.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "ToggleLikeActionCallback"
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/Widget.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/Widget.kt
@@ -1,65 +1,75 @@
 package com.shalenmathew.quotesapp.presentation.widget
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.Preferences
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
+import androidx.glance.currentState
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
+import androidx.glance.layout.Row
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.wrapContentHeight
 import androidx.glance.layout.wrapContentSize
+import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import com.shalenmathew.quotesapp.R
 import com.shalenmathew.quotesapp.presentation.MainActivity
-import com.shalenmathew.quotesapp.presentation.workmanager.widget.WidgetWorkManager
+import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_ID_KEY
 import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_KEY
+import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_LIKED_KEY
 import com.shalenmathew.quotesapp.util.dataStore
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import java.util.concurrent.TimeUnit
 
-object QuotesWidgetObj: GlanceAppWidget() {
+object QuotesWidgetObj : GlanceAppWidget() {
+
+    override val stateDefinition = PreferencesGlanceStateDefinition
 
     override suspend fun provideGlance(
         context: Context,
         id: GlanceId
     ) {
-        val savedQuote = runBlocking {
-            context.dataStore.data.first()[WIDGET_QUOTE_KEY] ?: "widget is refreshing, will be updated in some time.Or try rebooting the device"
-        }
+        // Fallback for widgets that haven't updated to Glance state yet
+        val deprecatedQuote = context.dataStore.data.first()[WIDGET_QUOTE_KEY]
 
-        Log.d("WID,","quote $savedQuote")
-
+        val defaultMessage =
+            "Widget is refreshing, will be updated in some time. Or try rebooting the device"
         provideContent {
-            QuoteWidget(savedQuote)
-        }
+            val prefs = currentState<Preferences>()
+            val savedQuote = prefs[WIDGET_QUOTE_KEY] ?: deprecatedQuote ?: defaultMessage
+            val quoteId = prefs[WIDGET_QUOTE_ID_KEY] ?: -1
+            val isLiked = prefs[WIDGET_QUOTE_LIKED_KEY] ?: false
 
+            QuoteWidget(
+                savedQuote = savedQuote,
+                isLiked = isLiked,
+                quoteId = quoteId,
+            )
+        }
     }
 }
 
 @Composable
-fun QuoteWidget(savedQuote: String) {
+fun QuoteWidget(savedQuote: String, isLiked: Boolean, quoteId: Int) {
     Column(
         modifier = GlanceModifier
             .fillMaxWidth()
@@ -87,17 +97,30 @@ fun QuoteWidget(savedQuote: String) {
             ),
             modifier = GlanceModifier.wrapContentSize().padding(horizontal = 15.dp, vertical = 15.dp)
         )
+
+        if (quoteId != -1) {
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.End
+            ) {
+                Image(
+                    provider = ImageProvider(
+                        if (isLiked) R.drawable.heart_filled
+                        else R.drawable.heart_unfilled
+                    ),
+                    contentDescription = "Like",
+                    modifier = GlanceModifier
+                        .size(28.dp)
+                        .padding(end = 8.dp, bottom = 8.dp)
+                        .clickable(
+                            actionRunCallback<ToggleLikeActionCallback>(
+                                actionParametersOf(
+                                    WidgetKeys.quoteIdKey to quoteId,
+                                )
+                            )
+                        )
+                )
+            }
+        }
     }
 }
-
-class QuotesWidgetReceiver: GlanceAppWidgetReceiver() {
-    override val glanceAppWidget: GlanceAppWidget
-        get() = QuotesWidgetObj
-
-    override fun onEnabled(context: Context) {
-        super.onEnabled(context)
-        Log.d("WorkManagerStatus", "Widget enabled, scheduling update")
-    }
-
-}
-

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/WidgetEntryPoint.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/WidgetEntryPoint.kt
@@ -1,0 +1,14 @@
+package com.shalenmathew.quotesapp.presentation.widget
+
+import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.LikedQuote
+import com.shalenmathew.quotesapp.domain.usecases.widget.UpdateWidgetUseCase
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface WidgetEntryPoint {
+    fun likedQuote(): LikedQuote
+    fun updateWidgetUseCase(): UpdateWidgetUseCase
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/WidgetKeys.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/widget/WidgetKeys.kt
@@ -1,0 +1,7 @@
+package com.shalenmathew.quotesapp.presentation.widget
+
+import androidx.glance.action.ActionParameters
+
+object WidgetKeys {
+    val quoteIdKey = ActionParameters.Key<Int>("quoteId")
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/widget/WidgetWorkManager.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/widget/WidgetWorkManager.kt
@@ -2,20 +2,17 @@ package com.shalenmathew.quotesapp.presentation.workmanager.widget
 
 import android.content.Context
 import android.util.Log
-import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.updateAll
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.shalenmathew.quotesapp.domain.model.Quote
 import com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases.QuoteUseCase
-import com.shalenmathew.quotesapp.presentation.widget.QuotesWidgetObj
+import com.shalenmathew.quotesapp.domain.usecases.widget.UpdateWidgetUseCase
 import com.shalenmathew.quotesapp.util.Constants.DEFAULT_WIDGET_REFRESH_INTERVAL
 import com.shalenmathew.quotesapp.util.Resource
-import com.shalenmathew.quotesapp.util.WIDGET_QUOTE_KEY
-import com.shalenmathew.quotesapp.util.dataStore
 import com.shalenmathew.quotesapp.util.getMillisFromNow
 import com.shalenmathew.quotesapp.util.getWidgetRefreshInterval
-import com.shalenmathew.quotesapp.util.saveWidgetQuote
+import com.shalenmathew.quotesapp.util.isWidgetCacheStale
 import com.shalenmathew.quotesapp.util.setLastAlarmTriggerMillis
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -26,99 +23,96 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 @HiltWorker
 class WidgetWorkManager @AssistedInject constructor(
-    @Assisted private val  context: Context,
+    @Assisted private val context: Context,
     @Assisted private val params: WorkerParameters,
     private val quoteUseCase: QuoteUseCase,
-    private val scheduleWidgetRefresh : ScheduleWidgetRefresh
-) : CoroutineWorker(context, params)
-{
+    private val scheduleWidgetRefresh: ScheduleWidgetRefresh,
+    private val updateWidgetUseCase: UpdateWidgetUseCase
+) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
+        return try {
+            Log.d(TAG, "Work started")
 
-      return  try {
+            val refreshInterval =
+                context.getWidgetRefreshInterval().first() ?: DEFAULT_WIDGET_REFRESH_INTERVAL
+            val isCacheStale = context.isWidgetCacheStale(refreshInterval)
 
-          Log.d("WorkManagerStatus", "Work started")
+            val success = if (isCacheStale) {
+                refreshAndUpdateWidget(refreshInterval)
+            } else {
+                updateWidgetFromCache()
+            }
 
-          val response = fetchQuotes(context)
+            if (success && isCacheStale) {
+                context.setLastAlarmTriggerMillis(System.currentTimeMillis())
+            }
 
-          if (!response){
-              return Result.retry()
-          }
-
-          val savedQuote = context.dataStore.data.first()[WIDGET_QUOTE_KEY] ?: "No quote saved yet!!!"
-          Log.d("WorkManagerStatus", "Saved Quote in DataStore work manager: $savedQuote")
-
-          val glanceAppWidgetManager = GlanceAppWidgetManager(applicationContext)
-          val widgetIds = glanceAppWidgetManager.getGlanceIds(QuotesWidgetObj::class.java)
-
-          if(widgetIds.isNotEmpty()){
-              widgetIds.forEach { it->
-                  QuotesWidgetObj.updateAll(applicationContext)
-              }
-          }
-
-          context.setLastAlarmTriggerMillis(System.currentTimeMillis())
-
-          return Result.success()
-
-        }
-      catch (e: Exception) {
-          Log.d("WorkManagerStatus", "Exception in doWork", e)
+            if (success) Result.success() else Result.retry()
+        } catch (e: Exception) {
+            Log.d(TAG, "Exception in doWork", e)
             Result.failure()
         }
-
     }
 
+    private suspend fun refreshAndUpdateWidget(refreshInterval: Int): Boolean {
+        scheduleWidgetRefresh.scheduleWidgetRefreshWorkAlarm(getMillisFromNow(refreshInterval))
+        val quote = fetchQuoteFromNetwork() ?: quoteUseCase.getLatestQuote()
+        return pushQuoteToWidget(quote)
+    }
 
-    private suspend fun fetchQuotes(context: Context):Boolean {
+    private suspend fun updateWidgetFromCache(): Boolean {
+        Log.d(TAG, "Cache is fresh, reading from local DB")
+        return pushQuoteToWidget(quoteUseCase.getLatestQuote())
+    }
 
-   return try {
+    private suspend fun fetchQuoteFromNetwork(): Quote? {
+        return try {
+            val response = withTimeoutOrNull(NETWORK_TIMEOUT_MILLIS) {
+                quoteUseCase.getQuote()
+                    .filter { it is Resource.Success || it is Resource.Error }
+                    .first()
+            }
 
-       Log.d("WorkManagerStatus", "inside fetchQuotes")
-
-     val response =
-         withTimeoutOrNull(5000) {
-             val refreshInterval = context.getWidgetRefreshInterval().first() ?: DEFAULT_WIDGET_REFRESH_INTERVAL
-             scheduleWidgetRefresh.scheduleWidgetRefreshWorkAlarm(getMillisFromNow(refreshInterval))
-             quoteUseCase.getQuote()
-                 .filter { it is Resource.Success || it is Resource.Error }
-                 .first()
-         }
-        when(response){
-
-            is Resource.Success->{
-                val quote =  response.data?.quotesList?.getOrNull(0)?.quote
-
-                if(quote!=null){
-                    Log.d("WorkManagerStatus", "Fetched Quote: $quote")
-                    context.saveWidgetQuote(quote)
-                     true
-                }else{
-                    Log.d("WorkManagerStatus", "Quote is null")
-                    false
+            when (response) {
+                is Resource.Success -> {
+                    Log.d(TAG, "Fetched quote from network")
+                    response.data?.quotesList?.getOrNull(0)
                 }
 
-            }
-            is Resource.Error-> {
-                Log.d("WorkManagerStatus", "Error from fetchQuotes: ${response.message}")
-                false
-            }
-            else -> {
-                Log.d("WorkManagerStatus", "No response from fetchQuotes")
-                false
-            }
-        }
+                is Resource.Error -> {
+                    Log.d(TAG, "Network error: ${response.message}")
+                    null
+                }
 
-    } catch (e: Exception){
-        Log.d("WorkManagerStatus", "Exception in fetchQuotes", e)
-      false
+                else -> {
+                    Log.d(TAG, "Network timeout")
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "Exception in fetchQuoteFromNetwork", e)
+            null
+        }
     }
 
-}
+    private suspend fun pushQuoteToWidget(quote: Quote?): Boolean {
+        if (quote == null) {
+            Log.d(TAG, "No quote available")
+            return false
+        }
+        updateWidgetUseCase(quote)
+            .onFailure { Log.w(TAG, "Widget update failed: ${it.message}") }
+        return true
+    }
+
+    companion object {
+        private const val TAG = "WidgetWorkManager"
+        private const val NETWORK_TIMEOUT_MILLIS = 5000L
+    }
 
     @AssistedFactory
     interface Factory {
         fun create(context: Context, params: WorkerParameters): WidgetWorkManager
     }
-
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/util/DataStore.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/util/DataStore.kt
@@ -1,8 +1,6 @@
 package com.shalenmathew.quotesapp.util
 
-import android.appwidget.AppWidgetManager
 import android.content.Context
-import android.content.Intent
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
@@ -11,15 +9,16 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
 import com.shalenmathew.quotesapp.domain.model.Quote
-import com.shalenmathew.quotesapp.presentation.widget.QuotesWidgetReceiver
-import com.shalenmathew.quotesapp.util.Constants.NO_QUOTE_SAVED_YET
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 
 val Context.dataStore by preferencesDataStore("quote_prefs")
 
 val WIDGET_QUOTE_KEY = stringPreferencesKey("widgetQuote")
+val WIDGET_QUOTE_ID_KEY = intPreferencesKey("widgetQuoteId")
+val WIDGET_QUOTE_LIKED_KEY = booleanPreferencesKey("widgetQuoteLiked")
 val NOTIFICATION_QUOTE_MODEL = stringPreferencesKey("notificationQuoteModel")
 
 val IS_FIRST_LAUNCH_KEY = booleanPreferencesKey("is_first_launch")
@@ -38,19 +37,6 @@ fun Context.isFirstLaunch(): Flow<Boolean> {
     }
 }
 
-suspend fun Context.saveWidgetQuote(quote: String) {
-    // saving quote of the day
-    dataStore.edit { preferences ->
-        preferences[WIDGET_QUOTE_KEY] = quote
-    }
-
-    val intent = Intent(this, QuotesWidgetReceiver::class.java).apply {
-        action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
-    }
-
-    sendBroadcast(intent)
-}
-
 suspend fun Context.saveNotificationQuote(quote: Quote){
     dataStore.edit { preferences ->
         preferences[NOTIFICATION_QUOTE_MODEL] = Gson().toJson(quote)
@@ -64,13 +50,6 @@ fun Context.getSavedNotificationQuote(): Flow<Quote?> {
         } else {
             return@map Gson().fromJson(preferences[NOTIFICATION_QUOTE_MODEL], Quote::class.java)
         }
-    }
-}
-
-
-fun Context.getSavedWidgetQuote(): Flow<String> {
-    return dataStore.data.map { preferences ->
-        preferences[WIDGET_QUOTE_KEY] ?: NO_QUOTE_SAVED_YET
     }
 }
 
@@ -96,4 +75,10 @@ fun Context.getLastAlarmTriggerMillis(): Flow<Long> {
     return dataStore.data.map { preferences ->
         preferences[LAST_ALARM_SET_MILLIS_KEY] ?: System.currentTimeMillis()
     }
+}
+
+suspend fun Context.isWidgetCacheStale(refreshInterval: Int): Boolean {
+    val lastTrigger = getLastAlarmTriggerMillis().first()
+    val now = System.currentTimeMillis()
+    return lastTrigger == 0L || (now - lastTrigger >= refreshInterval * 60_000L)
 }

--- a/app/src/test/java/com/shalenmathew/quotesapp/data/repository/QuoteRepositoryImplementationTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/data/repository/QuoteRepositoryImplementationTest.kt
@@ -1,0 +1,79 @@
+package com.shalenmathew.quotesapp.data.repository
+
+import com.shalenmathew.quotesapp.data.local.QuoteDao
+import com.shalenmathew.quotesapp.data.local.QuoteDatabase
+import com.shalenmathew.quotesapp.data.remote.QuoteApi
+import com.shalenmathew.quotesapp.domain.model.Quote
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(MockitoJUnitRunner::class)
+class QuoteRepositoryImplementationTest {
+
+    @Mock
+    private lateinit var api: QuoteApi
+
+    @Mock
+    private lateinit var db: QuoteDatabase
+
+    @Mock
+    private lateinit var quoteDao: QuoteDao
+
+    private lateinit var repository: QuoteRepositoryImplementation
+
+    @Before
+    fun setUp() {
+        whenever(db.getQuoteDao()).thenReturn(quoteDao)
+        repository = QuoteRepositoryImplementation(api, db)
+    }
+
+    @Test
+    fun `should return quote when getQuoteById is called with valid id`() = runTest {
+        val expectedQuote = Quote(1, "Test quote", "Test author", false)
+        whenever(quoteDao.getQuoteById(1)).thenReturn(expectedQuote)
+
+        val result = repository.getQuoteById(1)
+
+        assertEquals(expectedQuote, result)
+        verify(quoteDao).getQuoteById(1)
+    }
+
+    @Test
+    fun `should return null when getQuoteById is called with non-existent id`() = runTest {
+        whenever(quoteDao.getQuoteById(999)).thenReturn(null)
+
+        val result = repository.getQuoteById(999)
+
+        assertNull(result)
+        verify(quoteDao).getQuoteById(999)
+    }
+
+    @Test
+    fun `should return latest quote when getLatestQuote is called and quotes exist`() = runTest {
+        val expectedQuote = Quote(5, "Latest quote", "Latest author", false)
+        whenever(quoteDao.getLatestQuote()).thenReturn(expectedQuote)
+
+        val result = repository.getLatestQuote()
+
+        assertEquals(expectedQuote, result)
+        verify(quoteDao).getLatestQuote()
+    }
+
+    @Test
+    fun `should return null when getLatestQuote is called and no quotes exist`() = runTest {
+        whenever(quoteDao.getLatestQuote()).thenReturn(null)
+
+        val result = repository.getLatestQuote()
+
+        assertNull(result)
+        verify(quoteDao).getLatestQuote()
+    }
+}

--- a/app/src/test/java/com/shalenmathew/quotesapp/data/repository/WidgetRepositoryImplTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/data/repository/WidgetRepositoryImplTest.kt
@@ -1,0 +1,112 @@
+package com.shalenmathew.quotesapp.data.repository
+
+import androidx.glance.GlanceId
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.GlanceWidgetManager
+import com.shalenmathew.quotesapp.presentation.widget.QuotesWidgetObj
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(MockitoJUnitRunner::class)
+class WidgetRepositoryImplTest {
+
+    @Mock
+    private lateinit var glanceWidgetManager: GlanceWidgetManager
+
+    private lateinit var widgetRepository: WidgetRepositoryImpl
+
+    private val testQuote = Quote(id = 1, quote = "Test quote", author = "Author", liked = true)
+
+    @Before
+    fun setUp() {
+        widgetRepository = WidgetRepositoryImpl(glanceWidgetManager)
+    }
+
+    @Test
+    fun `updateWidget should return failure when quote id is null`() = runTest {
+        val result = widgetRepository.updateWidget(testQuote.copy(id = null))
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        verifyNoInteractions(glanceWidgetManager)
+    }
+
+    @Test
+    fun `updateWidget should return success when widget state is updated`() = runTest {
+        val mockGlanceId = mock<GlanceId>()
+        whenever(glanceWidgetManager.getWidgetIds(QuotesWidgetObj::class)).thenReturn(
+            listOf(mockGlanceId)
+        )
+
+        val result = widgetRepository.updateWidget(testQuote)
+
+        assertTrue(result.isSuccess)
+        verify(glanceWidgetManager).updateWidgetState(eq(mockGlanceId), any())
+        verify(glanceWidgetManager).updateAllWidgets(QuotesWidgetObj)
+    }
+
+    @Test
+    fun `updateWidget should return failure when exception occurs`() = runTest {
+        val mockGlanceId = mock<GlanceId>()
+        val exception = RuntimeException("Widget update failed")
+        whenever(glanceWidgetManager.getWidgetIds(QuotesWidgetObj::class)).thenReturn(
+            listOf(mockGlanceId)
+        )
+        whenever(glanceWidgetManager.updateWidgetState(any(), any())).thenThrow(exception)
+
+        val result = widgetRepository.updateWidget(testQuote)
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `updateWidgetIfSameOrEmpty should return failure when quote id is null`() = runTest {
+        val result = widgetRepository.updateWidgetIfSameOrEmpty(testQuote.copy(id = null))
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        verifyNoInteractions(glanceWidgetManager)
+    }
+
+    @Test
+    fun `updateWidgetIfSameOrEmpty should update when widget is empty`() = runTest {
+        val mockGlanceId = mock<GlanceId>()
+        whenever(glanceWidgetManager.getWidgetIds(QuotesWidgetObj::class)).thenReturn(
+            listOf(mockGlanceId)
+        )
+
+        val result = widgetRepository.updateWidgetIfSameOrEmpty(testQuote)
+
+        assertTrue(result.isSuccess)
+        verify(glanceWidgetManager).updateWidgetState(eq(mockGlanceId), any())
+        verify(glanceWidgetManager).updateAllWidgets(QuotesWidgetObj)
+    }
+
+    @Test
+    fun `updateWidgetIfSameOrEmpty should return failure when exception occurs`() = runTest {
+        val mockGlanceId = mock<GlanceId>()
+        val exception = RuntimeException("Widget update failed")
+        whenever(glanceWidgetManager.getWidgetIds(QuotesWidgetObj::class)).thenReturn(
+            listOf(mockGlanceId)
+        )
+        whenever(glanceWidgetManager.updateWidgetState(any(), any())).thenThrow(exception)
+
+        val result = widgetRepository.updateWidgetIfSameOrEmpty(testQuote)
+
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/GetLatestQuoteTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/GetLatestQuoteTest.kt
@@ -1,0 +1,49 @@
+package com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(MockitoJUnitRunner::class)
+class GetLatestQuoteTest {
+
+    @Mock
+    private lateinit var quoteRepository: QuoteRepository
+
+    private lateinit var getLatestQuote: GetLatestQuote
+
+    @Before
+    fun setUp() {
+        getLatestQuote = GetLatestQuote(quoteRepository)
+    }
+
+    @Test
+    fun `should return latest quote when quotes exist`() = runTest {
+        val expectedQuote = Quote(5, "Latest quote", "Author", false)
+        whenever(quoteRepository.getLatestQuote()).thenReturn(expectedQuote)
+
+        val result = getLatestQuote()
+
+        assertEquals(expectedQuote, result)
+        verify(quoteRepository).getLatestQuote()
+    }
+
+    @Test
+    fun `should return null when no quotes exist`() = runTest {
+        whenever(quoteRepository.getLatestQuote()).thenReturn(null)
+
+        val result = getLatestQuote()
+
+        assertNull(result)
+        verify(quoteRepository).getLatestQuote()
+    }
+}

--- a/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/LikedQuoteTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/home_screen_usecases/LikedQuoteTest.kt
@@ -1,0 +1,72 @@
+package com.shalenmathew.quotesapp.domain.usecases.home_screen_usecases
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.QuoteRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(MockitoJUnitRunner::class)
+class LikedQuoteTest {
+
+    @Mock
+    private lateinit var quoteRepository: QuoteRepository
+
+    private lateinit var likedQuote: LikedQuote
+
+    @Before
+    fun setUp() {
+        likedQuote = LikedQuote(quoteRepository)
+    }
+
+    @Test
+    fun `should toggle liked to true and save when quote is not liked`() = runTest {
+        val quote = Quote(1, "Test quote", "Author", false)
+
+        val result = likedQuote(quote)
+
+        assertEquals(true, result.liked)
+        assertEquals(quote.id, result.id)
+        verify(quoteRepository).saveLikedQuote(result)
+    }
+
+    @Test
+    fun `should toggle liked to false and save when quote is already liked`() = runTest {
+        val quote = Quote(1, "Test quote", "Author", true)
+
+        val result = likedQuote(quote)
+
+        assertEquals(false, result.liked)
+        assertEquals(quote.id, result.id)
+        verify(quoteRepository).saveLikedQuote(result)
+    }
+
+    @Test
+    fun `should fetch quote by id and toggle liked`() = runTest {
+        val existingQuote = Quote(1, "Test quote", "Author", false)
+        whenever(quoteRepository.getQuoteById(1)).thenReturn(existingQuote)
+
+        val result = likedQuote(1)
+
+        assertEquals(true, result!!.liked)
+        verify(quoteRepository).getQuoteById(1)
+        verify(quoteRepository).saveLikedQuote(result)
+    }
+
+    @Test
+    fun `should return null when quote id does not exist`() = runTest {
+        whenever(quoteRepository.getQuoteById(999)).thenReturn(null)
+
+        val result = likedQuote(999)
+
+        assertNull(result)
+        verify(quoteRepository).getQuoteById(999)
+    }
+}

--- a/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetIfSameOrEmptyUseCaseTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetIfSameOrEmptyUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.shalenmathew.quotesapp.domain.usecases.widget
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.WidgetRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdateWidgetIfSameOrEmptyUseCaseTest {
+
+    @Mock
+    private lateinit var widgetRepository: WidgetRepository
+
+    private lateinit var updateWidgetIfSameOrEmptyUseCase: UpdateWidgetIfSameOrEmptyUseCase
+
+    @Before
+    fun setUp() {
+        updateWidgetIfSameOrEmptyUseCase = UpdateWidgetIfSameOrEmptyUseCase(widgetRepository)
+    }
+
+    @Test
+    fun `should return success when repository updates widget successfully`() = runTest {
+        val quote = Quote(1, "quote", "author", true)
+        whenever(widgetRepository.updateWidgetIfSameOrEmpty(quote)).thenReturn(Result.success(Unit))
+
+        val result = updateWidgetIfSameOrEmptyUseCase(quote)
+
+        verify(widgetRepository).updateWidgetIfSameOrEmpty(quote)
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `should return failure when repository fails to update widget`() = runTest {
+        val quote = Quote(1, "quote", "author", true)
+        val exception = RuntimeException("Update failed")
+        whenever(widgetRepository.updateWidgetIfSameOrEmpty(quote)).thenReturn(
+            Result.failure(
+                exception
+            )
+        )
+
+        val result = updateWidgetIfSameOrEmptyUseCase(quote)
+
+        verify(widgetRepository).updateWidgetIfSameOrEmpty(quote)
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}

--- a/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetUseCaseTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/domain/usecases/widget/UpdateWidgetUseCaseTest.kt
@@ -1,0 +1,52 @@
+package com.shalenmathew.quotesapp.domain.usecases.widget
+
+import com.shalenmathew.quotesapp.domain.model.Quote
+import com.shalenmathew.quotesapp.domain.repository.WidgetRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdateWidgetUseCaseTest {
+
+    @Mock
+    private lateinit var widgetRepository: WidgetRepository
+
+    private lateinit var updateWidgetUseCase: UpdateWidgetUseCase
+
+    @Before
+    fun setUp() {
+        updateWidgetUseCase = UpdateWidgetUseCase(widgetRepository)
+    }
+
+    @Test
+    fun `should return success when repository updates widget successfully`() = runTest {
+        val quote = Quote(1, "quote", "author", true)
+        whenever(widgetRepository.updateWidget(quote)).thenReturn(Result.success(Unit))
+
+        val result = updateWidgetUseCase(quote)
+
+        verify(widgetRepository).updateWidget(quote)
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `should return failure when repository fails to update widget`() = runTest {
+        val quote = Quote(1, "quote", "author", true)
+        val exception = RuntimeException("Update failed")
+        whenever(widgetRepository.updateWidget(quote)).thenReturn(Result.failure(exception))
+
+        val result = updateWidgetUseCase(quote)
+
+        verify(widgetRepository).updateWidget(quote)
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+}


### PR DESCRIPTION
**What changed:**
- Added a clickable heart icon to the widget UI that toggles liked state
- Created ToggleLikeActionCallback to handle widget like interactions
- Implemented GlanceWidgetManager and WidgetRepository for widget state management
- Migrated widget from DataStore-only to Glance state (stores quote, ID, and liked status)
- Added getQuoteById() to QuoteDao and QuoteRepository
- Created UpdateWidgetUseCase and UpdateWidgetIfSameOrEmptyUseCase for widget updates
- Refactored error handling in QuoteRepository (extracted helper methods)
- Updated ViewModels to sync widget state when quotes are liked/unliked

**Why:**
Enables users to like/unlike quotes directly from the widget.

**How to test:**
1. Add the quotes widget to your home screen
2. Verify the heart icon appears for valid quotes
3. Tap the heart icon - it should toggle between filled/unfilled states
4. Open the app and verify the quote's liked state matches the widget
5. Like/unlike a quote in the app, then check the widget updates accordingly