### PR TITLE
feat: schedule daily notifications at a chosen time (closes #199)

### DIFF
--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/MainActivity.kt
@@ -27,11 +27,13 @@ import com.shalenmathew.quotesapp.presentation.workmanager.notification.Schedule
 import com.shalenmathew.quotesapp.presentation.workmanager.widget.ScheduleWidgetRefresh
 import com.shalenmathew.quotesapp.util.Constants
 import com.shalenmathew.quotesapp.util.Constants.DEFAULT_REFRESH_INTERVAL
+import com.shalenmathew.quotesapp.util.NotificationMode
 import com.shalenmathew.quotesapp.util.checkWorkManagerStatus
 import com.shalenmathew.quotesapp.util.getMillisFromNow
 import com.shalenmathew.quotesapp.util.getNotificationInterval
 import com.shalenmathew.quotesapp.util.getWidgetRefreshInterval
 import com.shalenmathew.quotesapp.util.setNotificationInterval
+import com.shalenmathew.quotesapp.util.setNotificationMode
 import com.shalenmathew.quotesapp.util.setWidgetRefreshInterval
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.first
@@ -79,6 +81,7 @@ class MainActivity : ComponentActivity() {
                     val notificationRefreshInterval = context.getNotificationInterval().first()
                     if (notificationRefreshInterval == null) {
                         context.setNotificationInterval(DEFAULT_REFRESH_INTERVAL)
+                        context.setNotificationMode(NotificationMode.FREQUENCY)
                         Handler(Looper.getMainLooper()).postDelayed({
                             scheduleNotification.scheduleNotificationWorkAlarm(
                                 getMillisFromNow(

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/navigation/AppNavigation.kt
@@ -12,6 +12,7 @@ import com.shalenmathew.quotesapp.presentation.screens.custom_quote.AddCustomQuo
 import com.shalenmathew.quotesapp.presentation.screens.fav_screen.FavScreen
 import com.shalenmathew.quotesapp.presentation.screens.home_screen.HomeScreen
 import com.shalenmathew.quotesapp.presentation.screens.intro_screen.SplashScreen
+import com.shalenmathew.quotesapp.presentation.screens.notification_time_screen.NotificationTimeScreen
 import com.shalenmathew.quotesapp.presentation.screens.settings_screen.more_apps.MoreApps
 import com.shalenmathew.quotesapp.presentation.screens.settings_screen.SettingsScreen
 import com.shalenmathew.quotesapp.presentation.screens.settings_screen.troubleshoot.Troubleshoot
@@ -71,6 +72,12 @@ fun AppNavigation(
         }
         composable(Screen.Troubleshoot.route){
             Troubleshoot(paddingValues)
+        }
+        composable(Screen.NotificationTime.route) {
+            NotificationTimeScreen(
+                paddingValues = paddingValues,
+                navHost = navHost
+            )
         }
 
         composable(Screen.WidgetSource.route) {

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/receivers/NotificationRefreshReceiver.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/receivers/NotificationRefreshReceiver.kt
@@ -5,18 +5,11 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import com.shalenmathew.quotesapp.presentation.workmanager.notification.ScheduleNotification
-import com.shalenmathew.quotesapp.util.Constants.DEFAULT_REFRESH_INTERVAL
-import com.shalenmathew.quotesapp.util.getLastNotificationAlarmTriggerMillis
-import com.shalenmathew.quotesapp.util.getMillisFromNow
-import com.shalenmathew.quotesapp.util.getNotificationInterval
-import com.shalenmathew.quotesapp.util.setLastNotificationAlarmTriggerMillis
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -32,24 +25,7 @@ class NotificationRefreshReceiver() : BroadcastReceiver() {
             try {
 
                 if (intent?.action == Intent.ACTION_BOOT_COMPLETED) {
-                    val lastAlarmSetTimeMillis =
-                        context?.getLastNotificationAlarmTriggerMillis()?.first()
-                            ?: getMillisFromNow(
-                                DEFAULT_REFRESH_INTERVAL
-                            )
-                    val notificationRefreshInterval = context?.getNotificationInterval()?.first()
-                        ?: DEFAULT_REFRESH_INTERVAL
-                    var timeToTrigger =
-                        lastAlarmSetTimeMillis + TimeUnit.HOURS.toMillis(notificationRefreshInterval.toLong())
-
-                    if (timeToTrigger <= System.currentTimeMillis()) {
-                        timeToTrigger = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(
-                            notificationRefreshInterval.toLong()
-                        )
-                    }
-
-                    notificationScheduler.scheduleNotificationWorkAlarm(timeToTrigger)
-                    context?.setLastNotificationAlarmTriggerMillis(timeToTrigger)
+                    notificationScheduler.rescheduleNext()
                 } else {
                     notificationScheduler.scheduleNotification()
                 }
@@ -61,6 +37,4 @@ class NotificationRefreshReceiver() : BroadcastReceiver() {
         }
 
     }
-
-
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/bottom_nav/BottomNav.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/bottom_nav/BottomNav.kt
@@ -206,6 +206,7 @@ sealed class Screen(
     object Troubleshoot : Screen("Troubleshoot", false)
     object AddCustomQuote : Screen("AddCustomQuote", false)
     object WidgetSource : Screen("WidgetSource", false)
+    object NotificationTime : Screen("NotificationTime", false)
     companion object {
         val values: List<Screen> = listOf(Home, Fav, Splash, Share, Settings, AboutLibraries)
     }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/notification_time_screen/NotificationTimeScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/notification_time_screen/NotificationTimeScreen.kt
@@ -105,7 +105,7 @@ fun NotificationTimeScreen(
                 fontFamily = GIFont,
                 fontWeight = FontWeight.Medium,
                 color = Color.White,
-                fontSize = 35.sp,
+                fontSize = 30.sp,
                 modifier = Modifier.padding(start = 8.dp)
             )
         }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/notification_time_screen/NotificationTimeScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/notification_time_screen/NotificationTimeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -114,6 +115,7 @@ fun NotificationTimeScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(78.dp)
+                .alpha(if (frequencyActive) 1f else 0.5f)
                 .clip(RoundedCornerShape(12.dp))
                 .background(customGrey2)
                 .padding(horizontal = 16.dp),
@@ -172,6 +174,7 @@ fun NotificationTimeScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(78.dp)
+                .alpha(if (dailyActive) 1f else 0.5f)
                 .clip(RoundedCornerShape(12.dp))
                 .background(customGrey2)
                 .clickable {

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/notification_time_screen/NotificationTimeScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/notification_time_screen/NotificationTimeScreen.kt
@@ -1,0 +1,228 @@
+package com.shalenmathew.quotesapp.presentation.screens.notification_time_screen
+
+import android.app.TimePickerDialog
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import com.shalenmathew.quotesapp.R
+import com.shalenmathew.quotesapp.presentation.screens.settings_screen.RefreshType
+import com.shalenmathew.quotesapp.presentation.screens.settings_screen.TimeDropdownMenu
+import com.shalenmathew.quotesapp.presentation.theme.GIFont
+import com.shalenmathew.quotesapp.presentation.theme.bratGreen
+import com.shalenmathew.quotesapp.presentation.theme.customGrey2
+import com.shalenmathew.quotesapp.presentation.viewmodel.SettingsViewModel
+import com.shalenmathew.quotesapp.util.Constants.DEFAULT_DAILY_NOTIFICATION_HOUR
+import com.shalenmathew.quotesapp.util.Constants.DEFAULT_DAILY_NOTIFICATION_MINUTE
+import com.shalenmathew.quotesapp.util.NotificationMode
+import com.shalenmathew.quotesapp.util.convertDaysToHrs
+import com.shalenmathew.quotesapp.util.formatDailyTime
+import com.shalenmathew.quotesapp.util.getNotificationDailyTime
+import com.shalenmathew.quotesapp.util.getNotificationMode
+import kotlinx.coroutines.flow.first
+
+@Composable
+fun NotificationTimeScreen(
+    paddingValues: PaddingValues,
+    navHost: NavHostController,
+    settingsViewModel: SettingsViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+
+    var mode by rememberSaveable { mutableStateOf(NotificationMode.FREQUENCY) }
+    var dailyHour by rememberSaveable { mutableIntStateOf(DEFAULT_DAILY_NOTIFICATION_HOUR) }
+    var dailyMinute by rememberSaveable { mutableIntStateOf(DEFAULT_DAILY_NOTIFICATION_MINUTE) }
+    var hasDailyTime by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        mode = context.getNotificationMode().first()
+        context.getNotificationDailyTime().first()?.let { (h, m) ->
+            dailyHour = h
+            dailyMinute = m
+            hasDailyTime = true
+        }
+    }
+
+    val frequencyActive = mode == NotificationMode.FREQUENCY
+    val dailyActive = mode == NotificationMode.DAILY_TIME
+
+    Column(
+        modifier = Modifier
+            .padding(paddingValues)
+            .fillMaxSize()
+            .background(Color.Black)
+            .padding(horizontal = 15.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 15.dp, horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { navHost.navigateUp() }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.White
+                )
+            }
+            Text(
+                text = "Notification Time",
+                fontFamily = GIFont,
+                fontWeight = FontWeight.Medium,
+                color = Color.White,
+                fontSize = 35.sp,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(78.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(customGrey2)
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ActiveIndicator(active = frequencyActive)
+            Image(
+                painter = painterResource(R.drawable.ic_notifications),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 12.dp)
+                    .size(30.dp)
+            )
+            Text(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 8.dp),
+                text = "Notify me every",
+                color = Color.White,
+                fontFamily = GIFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp
+            )
+            TimeDropdownMenu(
+                modifier = Modifier.widthIn(max = 120.dp),
+                onTimeSelected = {
+                    val interval = if (it.contains("days")) {
+                        convertDaysToHrs(it.removeSuffix("days").trim().toInt())
+                    } else {
+                        it.removeSuffix("hr").trim().toInt()
+                    }
+                    mode = NotificationMode.FREQUENCY
+                    settingsViewModel.applyFrequencyMode(interval)
+                },
+                isEnable = true,
+                refreshType = RefreshType.NOTIFICATION
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "or",
+                color = Color.White,
+                fontFamily = GIFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 14.sp
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(78.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(customGrey2)
+                .clickable {
+                    TimePickerDialog(
+                        context,
+                        { _, h, m ->
+                            dailyHour = h
+                            dailyMinute = m
+                            hasDailyTime = true
+                            mode = NotificationMode.DAILY_TIME
+                            settingsViewModel.applyDailyMode(h, m)
+                        },
+                        dailyHour,
+                        dailyMinute,
+                        false
+                    ).show()
+                }
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ActiveIndicator(active = dailyActive)
+            Image(
+                painter = painterResource(R.drawable.ic_notifications),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 12.dp)
+                    .size(30.dp)
+            )
+            Text(
+                modifier = Modifier.weight(1f),
+                text = if (hasDailyTime) {
+                    "Notify everyday at : ${formatDailyTime(dailyHour, dailyMinute)}"
+                } else {
+                    "Pick a time to be notified everyday"
+                },
+                color = Color.White,
+                fontFamily = GIFont,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActiveIndicator(active: Boolean) {
+    Box(
+        modifier = Modifier
+            .padding(end = 10.dp)
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(if (active) bratGreen else Color.Transparent)
+    )
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/settings_screen/SettingsScreen.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/screens/settings_screen/SettingsScreen.kt
@@ -3,12 +3,12 @@ package com.shalenmathew.quotesapp.presentation.screens.settings_screen
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MenuAnchorType
@@ -71,12 +72,10 @@ import com.shalenmathew.quotesapp.presentation.theme.customGrey4
 import com.shalenmathew.quotesapp.presentation.viewmodel.SettingsViewModel
 import com.shalenmathew.quotesapp.presentation.widget.QuotesWidgetReceiver
 import com.shalenmathew.quotesapp.util.Constants.DEFAULT_REFRESH_INTERVAL
-import com.shalenmathew.quotesapp.util.convertDaysToHrs
 import com.shalenmathew.quotesapp.util.convertHrsToDays
 import com.shalenmathew.quotesapp.util.getMillisFromNow
 import com.shalenmathew.quotesapp.util.getNotificationInterval
 import com.shalenmathew.quotesapp.util.getWidgetRefreshInterval
-import com.shalenmathew.quotesapp.util.setNotificationInterval
 import com.shalenmathew.quotesapp.util.setWidgetRefreshInterval
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -222,46 +221,33 @@ fun SettingsScreen(
                             )
                             .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
                             .background(customGrey2)
-                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                            .clickable {
+                                navHost.navigate(Screen.NotificationTime.route)
+                            }
+                            .padding(horizontal = 16.dp, vertical = 18.dp),
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Image(
-                            painter = painterResource(R.drawable.ic_notifications),
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Image(
+                                painter = painterResource(R.drawable.ic_notifications),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .padding(end = 12.dp)
+                                    .size(30.dp)
+                            )
+                            Text(
+                                text = "Schedule When to get notified",
+                                color = Color.White,
+                                fontFamily = GIFont,
+                                fontWeight = FontWeight.Medium,
+                                fontSize = 16.sp
+                            )
+                        }
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                             contentDescription = null,
-                            modifier = Modifier
-                                .padding(end = 12.dp)
-                                .size(30.dp)
-                        )
-                        Text(
-                            modifier = Modifier
-                                .weight(1f)
-                                .padding(end = 8.dp),
-                            text = "Notify me every",
-                            color = Color.White,
-                            fontFamily = GIFont,
-                            fontWeight = FontWeight.Medium,
-                            fontSize = 16.sp
-                        )
-                        TimeDropdownMenu(
-                            modifier = Modifier.widthIn(max = 120.dp),
-                            onTimeSelected = {
-                                val interval = if (it.contains("days")) {
-                                    convertDaysToHrs(it.removeSuffix("days").trim().toInt())
-                                } else {
-                                    it.removeSuffix("hr").trim().toInt()
-                                }
-                                Log.d("SettingsScreen", "onTimeSelected: $interval")
-                                coroutineScope.launch {
-                                    context.setNotificationInterval(interval = interval)
-                                }
-                                settingsViewModel.scheduleNotificationWorkAlarm(
-                                    getMillisFromNow(
-                                        interval
-                                    )
-                                )
-                            },
-                            isEnable = true,
-                            refreshType = RefreshType.NOTIFICATION
+                            tint = Color.White
                         )
                     }
                 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/viewmodel/SettingsViewModel.kt
@@ -16,8 +16,11 @@ class SettingsViewModel @Inject constructor(
         scheduleWidgetRefresh.scheduleWidgetRefreshWorkAlarm(triggerAtMillis)
     }
 
-    fun scheduleNotificationWorkAlarm(triggerAtMillis: Long) {
-        scheduleNotificationRefresh.scheduleNotificationWorkAlarm(triggerAtMillis)
+    fun applyFrequencyMode(intervalHours: Int) {
+        scheduleNotificationRefresh.applyFrequencyMode(intervalHours)
     }
 
+    fun applyDailyMode(hour: Int, minute: Int) {
+        scheduleNotificationRefresh.applyDailyMode(hour, minute)
+    }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/NotificationWorkManager.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/NotificationWorkManager.kt
@@ -12,7 +12,6 @@ import com.shalenmathew.quotesapp.util.Resource
 import com.shalenmathew.quotesapp.util.createOrUpdateNotification
 import com.shalenmathew.quotesapp.util.createNotificationChannel
 import com.shalenmathew.quotesapp.util.getMillisFromNow
-import com.shalenmathew.quotesapp.util.getNotificationInterval
 import com.shalenmathew.quotesapp.util.getSavedNotificationQuote
 import com.shalenmathew.quotesapp.util.saveNotificationQuote
 import com.shalenmathew.quotesapp.util.setLastNotificationAlarmTriggerMillis
@@ -65,15 +64,28 @@ class NotificationWorkManager @AssistedInject constructor(
 
             Log.d(Constants.WORK_MANAGER_STATUS_NOTIFY, "inside fetchQuotes")
 
+            try {
+                if (withTimeoutOrNull(2000) { scheduleNotification.rescheduleNext() } == null) {
+                    Log.w(
+                        Constants.WORK_MANAGER_STATUS_NOTIFY,
+                        "rescheduleNext timed out; using default-interval fallback"
+                    )
+                    scheduleNotification.scheduleNotificationWorkAlarm(
+                        getMillisFromNow(DEFAULT_REFRESH_INTERVAL)
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e(
+                    Constants.WORK_MANAGER_STATUS_NOTIFY,
+                    "rescheduleNext failed; using default-interval fallback",
+                    e
+                )
+                scheduleNotification.scheduleNotificationWorkAlarm(
+                    getMillisFromNow(DEFAULT_REFRESH_INTERVAL)
+                )
+            }
             val response =
                 withTimeoutOrNull(5000) {
-                    val refreshInterval =
-                        context.getNotificationInterval().first() ?: DEFAULT_REFRESH_INTERVAL
-                    scheduleNotification.scheduleNotificationWorkAlarm(
-                        getMillisFromNow(
-                            refreshInterval
-                        )
-                    )
                     quoteUseCase.getQuote()
                         .filter { it is Resource.Success || it is Resource.Error }
                         .first()

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/NotificationWorkManager.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/NotificationWorkManager.kt
@@ -65,7 +65,7 @@ class NotificationWorkManager @AssistedInject constructor(
             Log.d(Constants.WORK_MANAGER_STATUS_NOTIFY, "inside fetchQuotes")
 
             try {
-                if (withTimeoutOrNull(2000) { scheduleNotification.rescheduleNext() } == null) {
+                if (withTimeoutOrNull(5000) { scheduleNotification.rescheduleNext() } == null) {
                     Log.w(
                         Constants.WORK_MANAGER_STATUS_NOTIFY,
                         "rescheduleNext timed out; using default-interval fallback"

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/ScheduleNotification.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/ScheduleNotification.kt
@@ -44,22 +44,20 @@ class ScheduleNotification @Inject constructor(
     private val appScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     fun applyFrequencyMode(intervalHours: Int) {
+        scheduleNotificationWorkAlarm(getMillisFromNow(intervalHours))
         appScope.launch {
             context.setNotificationInterval(intervalHours)
             context.setNotificationMode(NotificationMode.FREQUENCY)
-
             context.setLastNotificationAlarmTriggerMillis(System.currentTimeMillis())
-            scheduleNotificationWorkAlarm(getMillisFromNow(intervalHours))
         }
     }
 
     fun applyDailyMode(hour: Int, minute: Int) {
+        scheduleNotificationWorkAlarm(nextDailyTriggerMillis(hour, minute))
         appScope.launch {
             context.setNotificationDailyTime(hour, minute)
             context.setNotificationMode(NotificationMode.DAILY_TIME)
-
             context.setLastNotificationAlarmTriggerMillis(System.currentTimeMillis())
-            scheduleNotificationWorkAlarm(nextDailyTriggerMillis(hour, minute))
         }
     }
 

--- a/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/ScheduleNotification.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/presentation/workmanager/notification/ScheduleNotification.kt
@@ -10,10 +10,27 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import com.shalenmathew.quotesapp.presentation.receivers.NotificationRefreshReceiver
+import com.shalenmathew.quotesapp.util.Constants.DEFAULT_REFRESH_INTERVAL
 import com.shalenmathew.quotesapp.util.Constants.QUOTES_NOTIFICATION
 import com.shalenmathew.quotesapp.util.Constants.REQUEST_CODE_NOTIFICATION_REFRESH
+import com.shalenmathew.quotesapp.util.NotificationMode
+import com.shalenmathew.quotesapp.util.getLastNotificationAlarmTriggerMillis
+import com.shalenmathew.quotesapp.util.getMillisFromNow
+import com.shalenmathew.quotesapp.util.getNotificationDailyTime
+import com.shalenmathew.quotesapp.util.getNotificationInterval
+import com.shalenmathew.quotesapp.util.getNotificationMode
+import com.shalenmathew.quotesapp.util.nextDailyTriggerMillis
 import com.shalenmathew.quotesapp.util.setLastNotificationAlarmTriggerMillis
+import com.shalenmathew.quotesapp.util.setNotificationDailyTime
+import com.shalenmathew.quotesapp.util.setNotificationInterval
+import com.shalenmathew.quotesapp.util.setNotificationMode
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,6 +38,30 @@ import javax.inject.Singleton
 class ScheduleNotification @Inject constructor(
     @param:ApplicationContext private val context: Context
 ) {
+
+    // This is an app-lifetime scope so persistence survives if the caller (Composable / ViewModel)
+    // is torn down between user action and DataStore commit completing.
+    private val appScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    fun applyFrequencyMode(intervalHours: Int) {
+        appScope.launch {
+            context.setNotificationInterval(intervalHours)
+            context.setNotificationMode(NotificationMode.FREQUENCY)
+
+            context.setLastNotificationAlarmTriggerMillis(System.currentTimeMillis())
+            scheduleNotificationWorkAlarm(getMillisFromNow(intervalHours))
+        }
+    }
+
+    fun applyDailyMode(hour: Int, minute: Int) {
+        appScope.launch {
+            context.setNotificationDailyTime(hour, minute)
+            context.setNotificationMode(NotificationMode.DAILY_TIME)
+
+            context.setLastNotificationAlarmTriggerMillis(System.currentTimeMillis())
+            scheduleNotificationWorkAlarm(nextDailyTriggerMillis(hour, minute))
+        }
+    }
 
     suspend fun scheduleNotification() {
 
@@ -57,6 +98,33 @@ class ScheduleNotification @Inject constructor(
             triggerAtMillis,
             pendingIntent
         )
+    }
+
+    suspend fun rescheduleNext() {
+        scheduleNotificationWorkAlarm(computeNextTriggerMillis())
+    }
+
+    private suspend fun computeNextTriggerMillis(): Long {
+        return when (context.getNotificationMode().first()) {
+            NotificationMode.DAILY_TIME -> {
+                val daily = context.getNotificationDailyTime().first()
+                if (daily != null) {
+                    nextDailyTriggerMillis(daily.first, daily.second)
+                } else {
+                    nextFrequencyTriggerMillis()
+                }
+            }
+            NotificationMode.FREQUENCY -> nextFrequencyTriggerMillis()
+        }
+    }
+
+    private suspend fun nextFrequencyTriggerMillis(): Long {
+        val interval = context.getNotificationInterval().first() ?: DEFAULT_REFRESH_INTERVAL
+        val intervalMillis = TimeUnit.HOURS.toMillis(interval.toLong())
+        val now = System.currentTimeMillis()
+        val lastTrigger = context.getLastNotificationAlarmTriggerMillis().first()
+        val candidate = lastTrigger + intervalMillis
+        return if (candidate > now) candidate else now + intervalMillis
     }
 
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/util/Constants.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/util/Constants.kt
@@ -11,6 +11,8 @@ object Constants {
     const val WORK_MANAGER_STATUS_NOTIFY = "WorkManagerStatusNotify"
     const val SHARED_PREFERENCES_NAME = "quotes_app_preferences"
     const val DEFAULT_REFRESH_INTERVAL = 24 // in hours
+    const val DEFAULT_DAILY_NOTIFICATION_HOUR = 8
+    const val DEFAULT_DAILY_NOTIFICATION_MINUTE = 0
     const val REQUEST_CODE_ALARM_WIDGET_REFRESH = 103
     const val REQUEST_CODE_NOTIFICATION_REFRESH = 104
     const val QUOTES_WIDGET_UPDATE_NAME = "quotes_widget_update"

--- a/app/src/main/java/com/shalenmathew/quotesapp/util/DataStore.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/util/DataStore.kt
@@ -28,6 +28,10 @@ val LAST_ALARM_SET_FOR_NOTIFICATION_MILLIS_KEY =
 val USER_PREF_WIDGET_REFRESH_INTERVAL_KEY = intPreferencesKey("user_pref_widget_refresh_interval")
 val USER_PREF_NOTIFICATION_INTERVAL_KEY = intPreferencesKey("user_pref_notification_interval")
 val WIDGET_SOURCE_KEY = stringPreferencesKey("widget_source")
+val USER_PREF_NOTIFICATION_MODE_KEY = stringPreferencesKey("user_pref_notification_mode")
+val USER_PREF_NOTIFICATION_DAILY_HOUR_KEY = intPreferencesKey("user_pref_notification_daily_hour")
+val USER_PREF_NOTIFICATION_DAILY_MINUTE_KEY =
+    intPreferencesKey("user_pref_notification_daily_minute")
 
 suspend fun Context.setFirstLaunchDone() {
     dataStore.edit { prefs ->
@@ -121,4 +125,31 @@ suspend fun Context.isWidgetCacheStale(refreshInterval: Int): Boolean {
     val lastTrigger = getLastAlarmTriggerMillis().first()
     val now = System.currentTimeMillis()
     return lastTrigger == 0L || (now - lastTrigger >= refreshInterval * 60_000L)
+}
+
+fun Context.getNotificationMode(): Flow<NotificationMode> {
+    return dataStore.data.map { preferences ->
+        NotificationMode.fromName(preferences[USER_PREF_NOTIFICATION_MODE_KEY])
+    }
+}
+
+suspend fun Context.setNotificationMode(mode: NotificationMode) {
+    dataStore.edit { preferences ->
+        preferences[USER_PREF_NOTIFICATION_MODE_KEY] = mode.name
+    }
+}
+
+fun Context.getNotificationDailyTime(): Flow<Pair<Int, Int>?> {
+    return dataStore.data.map { preferences ->
+        val hour = preferences[USER_PREF_NOTIFICATION_DAILY_HOUR_KEY]
+        val minute = preferences[USER_PREF_NOTIFICATION_DAILY_MINUTE_KEY]
+        if (hour != null && minute != null) hour to minute else null
+    }
+}
+
+suspend fun Context.setNotificationDailyTime(hour: Int, minute: Int) {
+    dataStore.edit { preferences ->
+        preferences[USER_PREF_NOTIFICATION_DAILY_HOUR_KEY] = hour
+        preferences[USER_PREF_NOTIFICATION_DAILY_MINUTE_KEY] = minute
+    }
 }

--- a/app/src/main/java/com/shalenmathew/quotesapp/util/NotificationMode.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/util/NotificationMode.kt
@@ -1,0 +1,11 @@
+package com.shalenmathew.quotesapp.util
+
+enum class NotificationMode {
+    FREQUENCY,
+    DAILY_TIME;
+
+    companion object {
+        fun fromName(name: String?): NotificationMode =
+            entries.firstOrNull { it.name == name } ?: FREQUENCY
+    }
+}

--- a/app/src/main/java/com/shalenmathew/quotesapp/util/util.kt
+++ b/app/src/main/java/com/shalenmathew/quotesapp/util/util.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.work.WorkManager
 import com.shalenmathew.quotesapp.util.Constants.QUOTES_NOTIFICATION
 import com.shalenmathew.quotesapp.util.Constants.QUOTES_WIDGET_UPDATE_NAME
+import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
 fun checkWorkManagerStatus(context: Context, lifecycleOwner: LifecycleOwner) {
@@ -48,4 +49,30 @@ fun convertDaysToHrs(days: Int): Int {
 
 fun convertHrsToDays(hours: Int): Int {
     return TimeUnit.HOURS.toDays(hours.toLong()).toInt()
+}
+
+fun nextDailyTriggerMillis(hour: Int, minute: Int): Long {
+    val now = Calendar.getInstance()
+    val target = Calendar.getInstance().apply {
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }
+    if (!target.after(now)) {
+        target.add(Calendar.DAY_OF_YEAR, 1)
+    }
+    return target.timeInMillis
+}
+
+fun formatDailyTime(hour: Int, minute: Int): String {
+    val isPm = hour >= 12
+    val displayHour = when {
+        hour == 0 -> 12
+        hour > 12 -> hour - 12
+        else -> hour
+    }
+    val mm = minute.toString().padStart(2, '0')
+    val suffix = if (isPm) "pm" else "am"
+    return "$displayHour:$mm $suffix"
 }

--- a/app/src/test/java/com/shalenmathew/quotesapp/presentation/viewmodel/CustomQuoteViewModelTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/presentation/viewmodel/CustomQuoteViewModelTest.kt
@@ -6,6 +6,7 @@ import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.DeleteCu
 import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.GetCustomQuotes
 import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.SaveCustomQuote
 import com.shalenmathew.quotesapp.domain.usecases.custom_quote_usecases.UpdateCustomQuote
+import com.shalenmathew.quotesapp.presentation.workmanager.widget.ScheduleWidgetRefresh
 import com.shalenmathew.quotesapp.presentation.screens.custom_quote.util.CustomQuoteEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -37,6 +38,8 @@ class CustomQuoteViewModelTest {
     private lateinit var deleteCustomQuote: DeleteCustomQuote
     @Mock
     private lateinit var updateCustomQuote: UpdateCustomQuote
+    @Mock
+    private lateinit var scheduleWidgetRefresh: ScheduleWidgetRefresh
 
     private lateinit var useCases: CustomQuoteUseCases
     private lateinit var viewModel: CustomQuoteViewModel
@@ -52,7 +55,7 @@ class CustomQuoteViewModelTest {
     @Test
     fun onEvent_SaveQuote_With_Blank_Author_Should_Save_As_Anonymous() = runTest {
         whenever(getCustomQuotes.invoke(any())).thenReturn(flowOf(emptyList()))
-        viewModel = CustomQuoteViewModel(useCases)
+        viewModel = CustomQuoteViewModel(useCases, scheduleWidgetRefresh)
         advanceUntilIdle()
 
         // Act
@@ -69,7 +72,7 @@ class CustomQuoteViewModelTest {
     @Test
     fun onEvent_OnSearchQueryChanged_Should_Update_Query_And_Refresh() = runTest {
         whenever(getCustomQuotes.invoke(any())).thenReturn(flowOf(emptyList()))
-        viewModel = CustomQuoteViewModel(useCases)
+        viewModel = CustomQuoteViewModel(useCases, scheduleWidgetRefresh)
         advanceUntilIdle()
 
         // Act
@@ -85,7 +88,7 @@ class CustomQuoteViewModelTest {
     @Test
     fun onEvent_DeleteQuote_Should_Call_UseCase() = runTest {
         whenever(getCustomQuotes.invoke(any())).thenReturn(flowOf(emptyList()))
-        viewModel = CustomQuoteViewModel(useCases)
+        viewModel = CustomQuoteViewModel(useCases, scheduleWidgetRefresh)
         advanceUntilIdle()
 
         val testQuote = CustomQuote(id = 1, quote = "Delete me", author = "tester")
@@ -101,7 +104,7 @@ class CustomQuoteViewModelTest {
     @Test
     fun onEvent_UpdateQuote_Should_Call_UseCase_And_Refresh() = runTest {
         whenever(getCustomQuotes.invoke(any())).thenReturn(flowOf(emptyList()))
-        viewModel = CustomQuoteViewModel(useCases)
+        viewModel = CustomQuoteViewModel(useCases, scheduleWidgetRefresh)
         advanceUntilIdle()
 
         val testQuote = CustomQuote(id = 1, quote = "Update me", author = "tester")

--- a/app/src/test/java/com/shalenmathew/quotesapp/presentation/workmanager/widget/WidgetWorkManagerTest.kt
+++ b/app/src/test/java/com/shalenmathew/quotesapp/presentation/workmanager/widget/WidgetWorkManagerTest.kt
@@ -117,7 +117,7 @@ class WidgetWorkManagerTest {
 
         assertNotNull(result)
         result?.let {
-            assertEquals(1, it.id)
+            assertEquals(100001, it.id)
             assertEquals("CQ1", it.quote)
             assertEquals("CA1", it.author)
             assertEquals(false, it.liked)


### PR DESCRIPTION
## Summary
Adds a "Schedule when to get notified" entry under Settings → Refresh Settings that opens a new screen letting users choose between two notification modes:

- **Frequency** : existing behavior (notify every N hours, e.g. 24 hr).
- **Daily time** : notify once a day at a user-picked time via `TimePickerDialog`. 

The selected mode + time persist in DataStore and survive process death; on alarm fire, the next trigger is computed from the active mode (interval vs. next occurrence of the chosen daily time).

Closes #199.

## Changes
- **New** `NotificationTimeScreen` with two cards (frequency / daily) and an active-state indicator dot.
- **New** `NotificationMode` enum (`FREQUENCY`, `DAILY_TIME`) persisted in DataStore.
- **New** DataStore keys for daily hour/minute and notification mode.
- **`ScheduleNotification`** now exposes `applyFrequencyMode(...)`, `applyDailyMode(hour, minute)`, and a `rescheduleNext()` that branches on mode to compute the next trigger. Writes go through an app-lifetime scope, so the DataStore commit survives Composable teardown.
- **`NotificationRefreshReceiver`** now calls `rescheduleNext()` so the chain self-perpetuates in either mode.
- **MainActivity** seeds `FREQUENCY` mode + 24 hr default on first launch (preserving prior behavior for existing users).                                                  - **`SettingsScreen`** replaces the inline "Notify me every" row with a navigation entry to the new screen, and switches from `CoroutineScope(Dispatchers.IO)` to `rememberCoroutineScope()` (fixes a per-recomposition scope leak).
- Theme: added `activeIndicator` color token. Constants: added `DEFAULT_DAILY_NOTIFICATION_HOUR/MINUTE`.

## How to test
1. Fresh install → notifications still default to every 24 hr (frequency mode).
2. Settings → Refresh Settings → "Schedule When to get notified".
3. Pick a time via the daily card → confirm a notification fires at that time today / the next day.
4. Switch back: choose an interval from the frequency card → confirm the daily alarm is replaced with an interval alarm.
5. Force-stop the app and reopen → selected mode + time persist (active dot is on the right card).
6. Reboot device → alarm reschedules from the persisted mode.